### PR TITLE
Session experience improvements + Teacher Memory

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,13 @@ line-bot-sdk>=3.14.0
 python-dotenv>=1.0.0
 streamlit>=1.40.0
 pytest>=8.0.0
+
+aiohttp>=3.9.0
+aiosqlite>=0.19.0
+scipy>=1.11.0
+networkx>=3.2.0
+pdfplumber>=0.10.0
+jinja2>=3.1.0
+rich>=13.0.0
+click>=8.1.0
+anthropic>=0.40.0

--- a/training_field/teacher_agent.py
+++ b/training_field/teacher_agent.py
@@ -71,7 +71,9 @@ class TeacherAgent:
         grade: int,
         subject: str,
         lang: str = "en",
+        session_memory: str = "",
     ) -> str:
+        memory_block = f"\n{session_memory}\n" if session_memory else ""
         frustration = student_emotional.get("frustration", 0.0)
         frustration_note = (
             f"\nFRUSTRATION ALERT: Student frustration is {frustration:.2f}. "
@@ -80,11 +82,16 @@ class TeacherAgent:
         )
 
         return f"""You are {self.config.name}, an AI tutor for a Grade {grade} {subject} student.
-
-=== FIELD CONTRACT (MANDATORY) ===
-ABSOLUTE RULE: Never give the direct answer. This is non-negotiable.
 {frustration_note}
 
+=== TEACHING RULES ===
+- Teach formulas, rules, and methods DIRECTLY. Do not make the student guess what they haven't learned yet.
+- After teaching a concept, verify understanding with ONE concrete practice problem.
+- If the student lacks prerequisite knowledge, teach the prerequisite first — briefly and directly.
+- Do NOT ask vague open-ended questions like "What do you think?" or "How would you approach this?"
+- Keep it conversational and encouraging, never lecturing.
+
+{memory_block}
 === YOUR TEACHING IDENTITY ===
 Philosophy: {self.config.teaching_philosophy}
 Warmth: {self.config.warmth:.1f}/1.0
@@ -101,7 +108,9 @@ Current phase: {phase} - Goal: {phase_goal}
 Student emotional state: confidence={student_emotional.get('confidence', 0.5):.2f}, frustration={frustration:.2f}
 
 === RESPONSE FORMAT ===
-Reply in {"English" if lang == "en" else "Japanese"}, 2-4 sentences, warm but intellectually challenging.
+Reply in {"English" if lang == "en" else "Japanese"}, max 3 sentences. Be direct, warm, and concise.
+End with ONE question or practice problem on its own line, prefixed with ▶ (e.g. "▶ 2/3 × 4/5 はいくつ？").
+Use plain text for math (e.g. 2/3 × 4/5 = 8/15). NEVER use LaTeX (no \\frac, \\times, \\div).
 Then output this JSON on a new line (no code block):
 {{"phase":"{phase}","scaffolding_level":1,"question_asked":true,"strategy_used":"skill name","emotional_read":{frustration:.2f}}}"""
 
@@ -118,11 +127,12 @@ Then output this JSON on a new line (no code block):
         subject: str = "算数",
         turn_number: int = 1,
         lang: str = "en",
+        session_memory: str = "",
     ) -> dict:
         system = self._build_system_prompt(
             topic, phase, phase_goal,
             student_name, student_proficiency, student_emotional,
-            grade, subject, lang
+            grade, subject, lang, session_memory
         )
         user_content = (
             f"Start the {phase} phase for unit '{topic}'. "
@@ -133,7 +143,7 @@ Then output this JSON on a new line (no code block):
 
         response = self.client.chat.completions.create(
             model="gpt-4o",
-            max_tokens=500,
+            max_tokens=300,
             messages=[{"role": "system", "content": system}, {"role": "user", "content": user_content}]
         )
         raw = response.choices[0].message.content

--- a/training_field/teacher_memory.py
+++ b/training_field/teacher_memory.py
@@ -1,0 +1,115 @@
+"""Teacher Session Memory — persists lessons learned across sessions.
+
+Config = who the teacher IS (immutable).
+Memory = what the teacher has LEARNED from past sessions (grows over time).
+"""
+from __future__ import annotations
+import json
+import datetime
+from collections import Counter
+from pathlib import Path
+
+MEMORY_DIR = Path(__file__).parent / "field" / "teacher_memory"
+MAX_SESSIONS = 5
+
+
+def extract_session_insights(
+    teacher_id: str,
+    session_id: str,
+    turn_evaluations: list,
+    evaluation,
+    update_check: dict,
+) -> dict:
+    directives = []
+    for ev in turn_evaluations:
+        d = ev.directive_to_teacher if hasattr(ev, "directive_to_teacher") else ""
+        if d and d not in directives:
+            directives.append(d)
+
+    metrics = {
+        "halluc_rate": round(getattr(evaluation, "hallucination_rate", 0) or 0, 3),
+        "direct_rate": round(getattr(evaluation, "direct_answer_rate", 0) or 0, 3),
+        "avg_zpd": round(getattr(evaluation, "avg_zpd_alignment", 0) or 0, 3),
+        "avg_bloom": round(getattr(evaluation, "avg_bloom_level", 0) or 0, 1),
+    }
+
+    recommendation = None
+    if update_check and update_check.get("trigger"):
+        recommendation = update_check.get("recommendation")
+
+    return {
+        "session_id": session_id,
+        "timestamp": datetime.datetime.now().isoformat(),
+        "metrics": metrics,
+        "directives": directives[:6],
+        "recommendation": recommendation,
+    }
+
+
+def save_memory(teacher_id: str, insight: dict) -> None:
+    MEMORY_DIR.mkdir(parents=True, exist_ok=True)
+    path = MEMORY_DIR / f"{teacher_id}.json"
+
+    if path.exists():
+        data = json.loads(path.read_text(encoding="utf-8"))
+    else:
+        data = {"teacher_id": teacher_id, "sessions": []}
+
+    data["sessions"].append(insight)
+    data["sessions"] = data["sessions"][-MAX_SESSIONS:]
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def load_memory_prompt(teacher_id: str) -> str:
+    path = MEMORY_DIR / f"{teacher_id}.json"
+    if not path.exists():
+        return ""
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return ""
+
+    sessions = data.get("sessions", [])
+    if not sessions:
+        return ""
+
+    directive_counts = Counter()
+    for s in sessions:
+        for d in s.get("directives", []):
+            directive_counts[d] += 1
+
+    top_directives = [d for d, _ in directive_counts.most_common(3)]
+
+    latest = sessions[-1].get("metrics", {})
+    first = sessions[0].get("metrics", {})
+    n = len(sessions)
+
+    def trend(key):
+        v0 = first.get(key, 0) or 0
+        v1 = latest.get(key, 0) or 0
+        if v1 > v0 + 0.05:
+            return f"{v0:.2f} → {v1:.2f} ↑"
+        elif v1 < v0 - 0.05:
+            return f"{v0:.2f} → {v1:.2f} ↓"
+        return f"{v1:.2f} (stable)"
+
+    lines = ["=== LESSONS FROM PAST SESSIONS ==="]
+
+    if top_directives:
+        for d in top_directives:
+            count = directive_counts[d]
+            lines.append(f"- {d} ({count}/{n} sessions)")
+
+    lines.append(f"- ZPD alignment: {trend('avg_zpd')}")
+    lines.append(f"- Hallucination rate: {trend('halluc_rate')}")
+
+    latest_rec = None
+    for s in reversed(sessions):
+        if s.get("recommendation"):
+            latest_rec = s["recommendation"]
+            break
+    if latest_rec:
+        lines.append(f"- Recommendation: {latest_rec}")
+
+    return "\n".join(lines)

--- a/training_field/teacher_registry.py
+++ b/training_field/teacher_registry.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Optional
 
 from training_field.teacher_agent import TeacherAgent
+from training_field.teacher_memory import load_memory_prompt
 
 EXTERNAL_DIR = Path(__file__).parent / "field" / "external_teachers"
 
@@ -60,18 +61,26 @@ def list_teachers() -> list[dict]:
 def load_teacher(teacher_id: Optional[str]) -> TeacherAgent:
     """Resolve a teacher_id to a fresh TeacherAgent instance.
     Falls back to Dr. Owen if teacher_id is None or unknown."""
-    if not teacher_id or teacher_id == "t001":
-        return TeacherAgent.create_dr_owen()
-    if teacher_id in _INTERNAL_FACTORIES:
-        return _INTERNAL_FACTORIES[teacher_id]()
-    if EXTERNAL_DIR.exists():
+    tid = teacher_id or "t001"
+    if tid == "t001" or not teacher_id:
+        agent = TeacherAgent.create_dr_owen()
+    elif tid in _INTERNAL_FACTORIES:
+        agent = _INTERNAL_FACTORIES[tid]()
+    elif EXTERNAL_DIR.exists():
+        agent = None
         for path in EXTERNAL_DIR.glob("*.json"):
             try:
                 with open(path, encoding="utf-8") as f:
                     data = json.load(f)
-                if data.get("teacher_id") == teacher_id:
-                    return TeacherAgent.from_json(path)
+                if data.get("teacher_id") == tid:
+                    agent = TeacherAgent.from_json(path)
+                    break
             except Exception:
                 continue
-    # Unknown teacher_id → fail loudly so the caller knows
-    raise ValueError(f"Unknown teacher_id: {teacher_id}")
+        if agent is None:
+            raise ValueError(f"Unknown teacher_id: {tid}")
+    else:
+        raise ValueError(f"Unknown teacher_id: {tid}")
+
+    agent.session_memory = load_memory_prompt(agent.config.teacher_id)
+    return agent

--- a/training_field/web/app.py
+++ b/training_field/web/app.py
@@ -294,33 +294,43 @@ def _test_prompt(teacher_config, topic, grade, subject, lang, question_num, tota
     dsubject = display_topic(subject, lang)
     return f"""You are {teacher_config.name}, giving a friendly {test_type} to {student_name}.
 Topic: {dtopic} (Grade {grade} {dsubject}).
-This is question {question_num} of {total_qs}.
+Question {question_num} of {total_qs}.
 
 RULES:
-- Ask ONE clear, specific question about {dtopic} appropriate for grade {grade}.
-- Keep it conversational and encouraging — NOT a formal exam tone.
-- {"Ask about concepts covered in today's lesson." if is_post else "Test their existing knowledge before the lesson."}
-- Each question should test a DIFFERENT aspect of the topic.
-- Reply in {"English" if lang == "en" else "Japanese"}.
-- End your message with the question. Do NOT answer it yourself.
-- Do NOT number the question — just ask it naturally."""
+- Ask ONE short, specific calculation question about {dtopic} for grade {grade}. Use concrete numbers.
+- 1 sentence only. No preamble, no encouragement, no "Let's see..." — just the question.
+- Start the question with ▶ (e.g. "▶ 2/3 × 3/4 はいくつ？").
+- {"Focus on concepts from today's lesson." if is_post else "Test existing knowledge before the lesson."}
+- Each question must test a DIFFERENT aspect.
+- Use plain text for math (e.g. 2/3 × 4/5, not LaTeX). NEVER use \\frac, \\times, \\div, etc.
+- Reply in {"English" if lang == "en" else "Japanese"}."""
 
 
 def _judge_prompt(teacher_config, topic, grade, lang, question_text, student_answer):
     """Build system prompt for judging a test answer."""
     dtopic = display_topic(topic, lang)
-    return f"""You are {teacher_config.name}, evaluating a student's answer.
+    return f"""You are {teacher_config.name}, evaluating a student's answer to a math question.
 
-The question was about "{dtopic}" (Grade {grade}).
+The question was: "{question_text}"
 Student answered: "{student_answer}"
 
 RULES:
-- Determine if the answer is correct, partially correct, or incorrect.
-- Give brief, encouraging feedback (1-2 sentences).
+- First, compute the correct answer yourself step by step.
+- Compare the student's answer to the correct answer.
+- BE LENIENT with format: accept partial answers, missing units, abbreviations, equivalent forms.
+  Examples of answers that MUST be marked correct:
+  - "70" when the answer is "70度" or "70 degrees"
+  - "1/2" when the answer is "0.5" or "2/4"
+  - "6" when the answer is "6cm²"
+  - A single number that matches the core numerical value
+- If the question asks for multiple values and the student gives one correct value, mark correct.
+- When in doubt, mark correct. This is a friendly check, not a strict exam.
+- Feedback: 1 sentence max. If correct, confirm briefly. If wrong, state the correct answer and show the key step.
+- Use plain text for math (e.g. 2/3, 3.14). NEVER use LaTeX (no \\frac, \\times, \\div, etc.).
 - Reply in {"English" if lang == "en" else "Japanese"}.
-- Start with a clear signal: "✓" if correct, "△" if partially correct, "✗" if incorrect.
+- Start with "✓" if correct, "✗" if incorrect.
 - Then on a NEW LINE, add this exact JSON (no code block):
-{{"correct": true_or_false, "question": "the original question you asked", "explanation": "brief correct answer explanation"}}"""
+{{"correct": true_or_false, "question": "{question_text}", "explanation": "the correct answer and one-line explanation"}}"""
 
 LIVE_SESSIONS: dict[str, LiveSession] = {}
 
@@ -393,6 +403,12 @@ async def live_respond(session_id: str, body: dict):
     student_text = body.get("text", "").strip()
     if not student_text:
         raise HTTPException(400, "text is required")
+
+    # Allow client to update language mid-session (so subsequent teacher/judge
+    # messages switch language too).
+    new_lang = body.get("lang")
+    if new_lang in ("en", "ja"):
+        session.lang = new_lang
 
     teacher = session.teacher
     from openai import OpenAI
@@ -479,6 +495,7 @@ async def live_respond(session_id: str, body: dict):
                 student_last_response=None,
                 grade=session.grade, subject=dsubject,
                 turn_number=1, lang=session.lang,
+                session_memory=getattr(teacher, "session_memory", ""),
             )
             session.last_teacher_text = tr["text"]
 
@@ -593,6 +610,7 @@ async def live_respond(session_id: str, body: dict):
         student_last_response=student_text,
         grade=session.grade, subject=dsubject,
         turn_number=session.current_turn, lang=session.lang,
+        session_memory=getattr(teacher, "session_memory", ""),
     )
     session.last_teacher_text = tr["text"]
 
@@ -608,6 +626,19 @@ async def live_respond(session_id: str, body: dict):
         "proficiency": round(session.proficiency, 1),
         "is_complete": False,
     }
+
+
+@app.post("/api/live/{session_id}/lang")
+async def live_set_lang(session_id: str, body: dict):
+    """Update the active language for an in-progress live session."""
+    session = LIVE_SESSIONS.get(session_id)
+    if not session:
+        raise HTTPException(404, "session not found or expired")
+    new_lang = body.get("lang")
+    if new_lang not in ("en", "ja"):
+        raise HTTPException(400, "lang must be 'en' or 'ja'")
+    session.lang = new_lang
+    return {"ok": True, "lang": session.lang}
 
 
 @app.get("/api/live/{session_id}")
@@ -671,6 +702,12 @@ def _save_live_session(session: LiveSession):
             session_grade="—",
         )
         registry.register(record)
+        from training_field.teacher_memory import extract_session_insights, save_memory
+        insight = extract_session_insights(
+            session.teacher.config.teacher_id, session.session_id,
+            session.turn_evaluations, evaluation, update_check,
+        )
+        save_memory(session.teacher.config.teacher_id, insight)
         transcript = {
             "session_id": session.session_id, "timestamp": session.started_at,
             "student_id": "human", "student_name": session.student_label,
@@ -958,7 +995,7 @@ async def run_session(body: dict):
     for phase in phases:
         for turn_num in range(1, phase["turns"] + 1):
             current_prof = student.proficiency_model.topic_proficiencies.get(config.topic, student.proficiency_model.proficiency)
-            tr = await teacher.get_response(topic=config.topic, phase=phase["name"], phase_goal=phase["goal"], student_name=student.name, student_proficiency=current_prof, student_emotional=student.emotional_state.__dict__, student_last_response=last_student_text, grade=config.grade, subject=config.subject, turn_number=turn_num)
+            tr = await teacher.get_response(topic=config.topic, phase=phase["name"], phase_goal=phase["goal"], student_name=student.name, student_proficiency=current_prof, student_emotional=student.emotional_state.__dict__, student_last_response=last_student_text, grade=config.grade, subject=config.subject, turn_number=turn_num, session_memory=getattr(teacher, "session_memory", ""))
             sr = await student.get_response(teacher_message=tr["text"], topic=config.topic, phase=phase["name"])
             ev = await principal.evaluate_turn(teacher_text=tr["text"], student_text=sr["text"], topic=config.topic, phase=phase["name"], student_proficiency=current_prof, grade=config.grade, subject=config.subject)
             turn_evaluations.append(ev)
@@ -994,6 +1031,12 @@ async def run_session(body: dict):
     evaluator.generate_report(evaluation)
     record = ExperimentRecord(exp_id=session_id, hypothesis_id=None, timestamp=datetime.datetime.now().isoformat(), student_id=config.student_id, teacher_id=teacher.config.teacher_id, topic=config.topic, grade=config.grade, subject=config.subject, depth=config.depth, teaching_style="SOCRATIC", skills_used=teacher.config.selected_skills, pre_test_score=pre_test_score, post_test_score=post_test_score, learning_gain=evaluation.learning_gain, proficiency_delta=evaluation.proficiency_delta, hallucination_rate=evaluation.hallucination_rate, direct_answer_rate=evaluation.direct_answer_rate, avg_zpd_alignment=evaluation.avg_zpd_alignment, avg_bloom_level=evaluation.avg_bloom_level, frustration_events=evaluation.frustration_events, aha_moments=evaluation.aha_moments, teacher_compatibility_score=evaluation.teacher_compatibility_score, total_tokens=evaluation.total_tokens_used, cost_usd=evaluation.estimated_cost_usd, session_grade=grade_result["grade"])
     registry.register(record)
+    from training_field.teacher_memory import extract_session_insights, save_memory
+    _insight = extract_session_insights(
+        teacher.config.teacher_id, session_id,
+        turn_evaluations, evaluation, update_check,
+    )
+    save_memory(teacher.config.teacher_id, _insight)
     transcript = {
         "session_id": session_id, "timestamp": record.timestamp,
         "student_id": config.student_id, "teacher_id": teacher.config.teacher_id,
@@ -1085,6 +1128,7 @@ async def run_session_stream(
                     student_last_response=last_student_text,
                     grade=config.grade, subject=dsubject, turn_number=turn_num,
                     lang=lang,
+                    session_memory=getattr(teacher, "session_memory", ""),
                 )
                 yield f"data: {json.dumps({'type':'teacher','text':tr['text'],'turn':turn_num,'total':total})}\n\n"
                 await asyncio.sleep(0.3)
@@ -1177,6 +1221,12 @@ async def run_session_stream(
                 session_grade=(grade_result or {}).get("grade", "—"),
             )
             registry.register(record)
+            from training_field.teacher_memory import extract_session_insights, save_memory
+            _insight = extract_session_insights(
+                teacher.config.teacher_id, session_id,
+                turn_evaluations, evaluation, update_check,
+            )
+            save_memory(teacher.config.teacher_id, _insight)
             # Save full transcript for the history viewer (turn-by-turn replay)
             transcript = {
                 "session_id": session_id,

--- a/training_field/web/templates/dashboard.html
+++ b/training_field/web/templates/dashboard.html
@@ -290,13 +290,13 @@ tbody tr:hover{background:var(--surface-2)}
     <div style="display:flex;gap:16px;margin-top:48px;flex-wrap:wrap">
       <a href="#observatory" class="portal-card" style="flex:1;min-width:260px;text-decoration:none;color:inherit;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);padding:28px;box-shadow:var(--shadow-sm);transition:transform .3s var(--ease),box-shadow .3s var(--ease)">
         <div style="font-size:24px;margin-bottom:10px">👀</div>
-        <div style="font-size:17px;font-weight:600;letter-spacing:-0.015em">Observatory</div>
-        <div style="font-size:13px;color:var(--muted);margin-top:4px">Watch AI agents teach and learn. Run experiments and compare results.</div>
+        <div style="font-size:17px;font-weight:600;letter-spacing:-0.015em" data-i18n="portal_observatory_title">Observatory</div>
+        <div style="font-size:13px;color:var(--muted);margin-top:4px" data-i18n="portal_observatory_desc">Watch AI agents teach and learn. Run experiments and compare results.</div>
       </a>
       <a href="/learn" class="portal-card" style="flex:1;min-width:260px;text-decoration:none;color:inherit;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);padding:28px;box-shadow:var(--shadow-sm);transition:transform .3s var(--ease),box-shadow .3s var(--ease)">
         <div style="font-size:24px;margin-bottom:10px">📚</div>
-        <div style="font-size:17px;font-weight:600;letter-spacing:-0.015em">Start Learning</div>
-        <div style="font-size:13px;color:var(--muted);margin-top:4px">Join as a real student. Pick a teacher, choose a topic, and start your session.</div>
+        <div style="font-size:17px;font-weight:600;letter-spacing:-0.015em" data-i18n="portal_learn_title">Start Learning</div>
+        <div style="font-size:13px;color:var(--muted);margin-top:4px" data-i18n="portal_learn_desc">Join as a real student. Pick a teacher, choose a topic, and start your session.</div>
       </a>
     </div>
   </section>
@@ -381,8 +381,10 @@ tbody tr:hover{background:var(--surface-2)}
 </main>
 
 <script>
-const GRADES = ["小1","小2","小3","小4","小5","小6","中1","中2","中3","高1","高2","高3"];
+const GRADES = ["小6","小1","小2","小3","小4","小5","中1","中2","中3","高1","高2","高3"];
 const SUBJECTS = ["算数","国語","理科","社会","英語"];
+const AVAILABLE_GRADES = new Set(["小6"]);
+const AVAILABLE_SUBJECTS = new Set(["算数"]);
 const I18N = {
   ja: {
     students_label:"生徒エージェント", recent_sessions:"最近のセッション",
@@ -393,6 +395,10 @@ const I18N = {
     title_main:"AIエージェントが教え方を",
     title_faded:"学び、試し、本質を持ち帰るための静かな場。",
     title_sub:"現在、6種類の生徒ペルソナ、6種類のスキル(教え方)、5つの評価軸を備え、エージェントが成長のためのインサイトを得られます。",
+    portal_observatory_title:"オブザーバトリー",
+    portal_observatory_desc:"AIエージェントが教え学ぶ様子を観察。実験を実行して結果を比較できます。",
+    portal_learn_title:"学習を始める",
+    portal_learn_desc:"実際の生徒として参加。先生を選び、単元を決めて、セッションを開始しましょう。",
     topic_分数:"分数", topic_比:"比", topic_速さ:"速さ", topic_比例:"比例", topic_円:"円", topic_場合:"場合の数",
   },
   en: {
@@ -404,6 +410,10 @@ const I18N = {
     title_main:"A calm space for AI agents",
     title_faded:"to learn and experiment with how to teach and get key takeaways.",
     title_sub:"Currently, there are six types of student personas, six types of skills (ways to teach), and five pillars of evaluation feedback for agents to gain insights for growth.",
+    portal_observatory_title:"Observatory",
+    portal_observatory_desc:"Watch AI agents teach and learn. Run experiments and compare results.",
+    portal_learn_title:"Start Learning",
+    portal_learn_desc:"Join as a real student. Pick a teacher, choose a topic, and start your session.",
     topic_分数:"Fractions", topic_比:"Ratios", topic_速さ:"Speed", topic_比例:"Proportion", topic_円:"Circles", topic_場合:"Combinatorics",
   }
 };
@@ -420,19 +430,26 @@ function translateContent(el,l){
 }
 let curLang = localStorage.getItem("tfLang") || "en";
 
-function fillSelect(sel, items, saved){
+function fillSelect(sel, items, saved, available){
   sel.innerHTML = "";
+  const comingSoon = curLang==="ja" ? "（近日対応）" : " (coming soon)";
   items.forEach(v=>{
     const o=document.createElement("option");
-    o.value=v; o.dataset.src=v; o.textContent=tx(v,curLang);
+    o.value=v; o.dataset.src=v;
+    const enabled = !available || available.has(v);
+    o.textContent = tx(v,curLang) + (enabled ? "" : comingSoon);
+    if(!enabled) o.disabled = true;
     sel.appendChild(o);
   });
-  if(saved && items.includes(saved)) sel.value=saved;
+  const savedOk = saved && items.includes(saved) && (!available || available.has(saved));
+  sel.value = savedOk ? saved : items.find(v=>!available || available.has(v));
 }
 const gradeSel=document.getElementById("gradeSel");
 const subjSel=document.getElementById("subjSel");
-fillSelect(gradeSel, GRADES, localStorage.getItem("tfGrade")||"小6");
-fillSelect(subjSel, SUBJECTS, localStorage.getItem("tfSubject")||"算数");
+fillSelect(gradeSel, GRADES, localStorage.getItem("tfGrade")||"小6", AVAILABLE_GRADES);
+fillSelect(subjSel, SUBJECTS, localStorage.getItem("tfSubject")||"算数", AVAILABLE_SUBJECTS);
+localStorage.setItem("tfGrade", gradeSel.value);
+localStorage.setItem("tfSubject", subjSel.value);
 function updateCardLinks(){
   const g=encodeURIComponent(gradeSel.value), s=encodeURIComponent(subjSel.value);
   document.querySelectorAll(".stu-card").forEach(a=>{
@@ -448,8 +465,12 @@ function applyLang(l){
     const k=el.getAttribute("data-i18n");
     if(I18N[l] && I18N[l][k]) el.textContent = I18N[l][k];
   });
-  [gradeSel,subjSel].forEach(sel=>{
-    Array.from(sel.options).forEach(o=>{ o.textContent = tx(o.dataset.src,l); });
+  const comingSoon = l==="ja" ? "（近日対応）" : " (coming soon)";
+  [[gradeSel,AVAILABLE_GRADES],[subjSel,AVAILABLE_SUBJECTS]].forEach(([sel,avail])=>{
+    Array.from(sel.options).forEach(o=>{
+      const enabled = avail.has(o.dataset.src);
+      o.textContent = tx(o.dataset.src,l) + (enabled ? "" : comingSoon);
+    });
   });
   document.querySelectorAll("[data-i18n-tx]").forEach(el=>translateContent(el,l));
   const b=document.getElementById("langbtn"); if(b) b.textContent = l==="ja"?"EN":"JA";

--- a/training_field/web/templates/learn.html
+++ b/training_field/web/templates/learn.html
@@ -42,6 +42,13 @@ body{
   padding:8px 16px;border:1px solid var(--border-strong);border-radius:var(--radius-pill);
 }
 .back-link:hover{color:var(--text);background:var(--surface-2)}
+.lang-link{
+  position:absolute;top:24px;right:24px;
+  color:var(--text);background:var(--surface);text-decoration:none;font-size:12px;font-weight:600;
+  padding:8px 16px;border:1px solid var(--border-strong);border-radius:var(--radius-pill);
+  cursor:pointer;font-family:inherit;letter-spacing:0.04em;
+}
+.lang-link:hover{background:var(--surface-2)}
 h1{font-size:28px;font-weight:600;letter-spacing:-0.025em;margin-bottom:8px}
 .subtitle{font-size:15px;color:var(--muted);margin-bottom:36px}
 .welcome{font-size:22px;font-weight:600;margin-bottom:6px;letter-spacing:-0.02em}
@@ -101,45 +108,34 @@ h1{font-size:28px;font-weight:600;letter-spacing:-0.025em;margin-bottom:8px}
 </head>
 <body>
 <script>(function(){var t=localStorage.getItem("tfTheme")||"light";document.documentElement.setAttribute("data-theme",t);})();</script>
-<a href="/" class="back-link">← Training Field</a>
+<a href="/" class="back-link" data-i18n="back_training">← Training Field</a>
+<button class="lang-link" id="langbtn" onclick="toggleLang()">JA</button>
 
 <!-- Onboarding (shown if no saved profile) -->
 <div class="card" id="onboard">
-  <h1>Start Learning</h1>
-  <p class="subtitle">Tell us a little about yourself so we can match you with the right teacher.</p>
+  <h1 data-i18n="start_learning">Start Learning</h1>
+  <p class="subtitle" data-i18n="onboard_subtitle">Tell us a little about yourself so we can match you with the right teacher.</p>
   <div class="form-group">
-    <label class="form-label">YOUR NAME</label>
-    <input type="text" class="form-input" id="nameInput" placeholder="e.g. Emma" autocomplete="given-name">
+    <label class="form-label" data-i18n="label_name">YOUR NAME</label>
+    <input type="text" class="form-input" id="nameInput" placeholder="e.g. Emma" data-i18n-placeholder="name_placeholder" autocomplete="given-name">
   </div>
   <div class="form-group">
-    <label class="form-label">GRADE</label>
-    <select class="form-select" id="gradeInput">
-      <option value="小1">Grade 1</option><option value="小2">Grade 2</option>
-      <option value="小3">Grade 3</option><option value="小4">Grade 4</option>
-      <option value="小5">Grade 5</option><option value="小6" selected>Grade 6</option>
-      <option value="中1">Jr High 1</option><option value="中2">Jr High 2</option><option value="中3">Jr High 3</option>
-      <option value="高1">High 1</option><option value="高2">High 2</option><option value="高3">High 3</option>
-    </select>
+    <label class="form-label" data-i18n="label_grade">GRADE</label>
+    <select class="form-select" id="gradeInput"></select>
   </div>
   <div class="form-group">
-    <label class="form-label">SUBJECT</label>
-    <select class="form-select" id="subjectInput">
-      <option value="算数">Math</option>
-      <option value="国語">Japanese</option>
-      <option value="理科">Science</option>
-      <option value="社会">Social Studies</option>
-      <option value="英語">English</option>
-    </select>
+    <label class="form-label" data-i18n="label_subject">SUBJECT</label>
+    <select class="form-select" id="subjectInput"></select>
   </div>
   <div class="form-group">
-    <label class="form-label">TEACHER</label>
+    <label class="form-label" data-i18n="label_teacher">TEACHER</label>
     <select class="form-select" id="teacherInput">
       {% for t in teachers %}
       <option value="{{ t.teacher_id }}">{{ t.name }} — {{ t.origin }}</option>
       {% endfor %}
     </select>
   </div>
-  <button class="btn-primary" onclick="registerStudent()">Let's Go</button>
+  <button class="btn-primary" onclick="registerStudent()" data-i18n="lets_go">Let's Go</button>
 </div>
 
 <!-- Welcome back (shown if profile exists) -->
@@ -147,15 +143,15 @@ h1{font-size:28px;font-weight:600;letter-spacing:-0.025em;margin-bottom:8px}
   <div class="welcome" id="welcomeMsg">Welcome back!</div>
   <div class="welcome-sub" id="welcomeSub"></div>
 
-  <div class="form-label">YOUR PROGRESS</div>
+  <div class="form-label" data-i18n="label_progress">YOUR PROGRESS</div>
   <div class="prof-grid" id="profGrid"></div>
 
   <div class="form-group">
-    <label class="form-label">TOPIC</label>
+    <label class="form-label" data-i18n="label_topic">TOPIC</label>
     <select class="form-select" id="topicSelect"></select>
   </div>
   <div class="form-group">
-    <label class="form-label">TEACHER</label>
+    <label class="form-label" data-i18n="label_teacher">TEACHER</label>
     <select class="form-select" id="teacherSelect">
       {% for t in teachers %}
       <option value="{{ t.teacher_id }}">{{ t.name }} — {{ t.origin }}</option>
@@ -163,22 +159,116 @@ h1{font-size:28px;font-weight:600;letter-spacing:-0.025em;margin-bottom:8px}
     </select>
   </div>
   <div class="form-group">
-    <label class="form-label">DEPTH</label>
+    <label class="form-label" data-i18n="label_depth">DEPTH</label>
     <select class="form-select" id="depthSelect">
-      <option value="quick">Quick · 8 turns</option>
-      <option value="standard" selected>Standard · 12 turns</option>
-      <option value="deep">Deep · 16 turns</option>
+      <option value="quick" data-i18n="depth_quick">Quick · 8 turns</option>
+      <option value="standard" selected data-i18n="depth_standard">Standard · 12 turns</option>
+      <option value="deep" data-i18n="depth_deep">Deep · 16 turns</option>
     </select>
   </div>
-  <button class="btn-primary" onclick="startSession()">Start Session</button>
+  <button class="btn-primary" onclick="startSession()" data-i18n="start_session">Start Session</button>
 
   <div class="history-list" id="historyList"></div>
-  <a href="#" class="new-session-link" onclick="resetProfile();return false;">Switch student</a>
+  <a href="#" class="new-session-link" onclick="resetProfile();return false;" data-i18n="switch_student">Switch student</a>
 </div>
 
 <script>
 const TEACHERS = {{ teachers|tojson }};
 const TOPIC_TX = {{ topic_tx_en|tojson }};
+
+// ── i18n ─────────────────────────────────────────
+const I18N = {
+  ja: {
+    back_training:"← Training Field",
+    start_learning:"学習を始めよう",
+    onboard_subtitle:"少しだけ自己紹介してください。あなたにぴったりの先生を選びます。",
+    label_name:"なまえ", name_placeholder:"例：エマ",
+    label_grade:"がくねん", label_subject:"きょうか", label_teacher:"せんせい",
+    label_progress:"これまでの学習", label_topic:"単元", label_depth:"深さ",
+    depth_quick:"クイック · 8ターン", depth_standard:"標準 · 12ターン", depth_deep:"じっくり · 16ターン",
+    lets_go:"はじめる", start_session:"セッション開始", switch_student:"別の生徒に切り替え",
+    welcome_back:n=>"おかえりなさい、"+n+"さん！",
+    welcome_sub:(g,s,n)=>g+" · "+s+" · "+n+" セッション完了",
+    no_topics_yet:"まだ学習した単元はありません",
+    sessions_completed:"セッション完了",
+  },
+  en: {
+    back_training:"← Training Field",
+    start_learning:"Start Learning",
+    onboard_subtitle:"Tell us a little about yourself so we can match you with the right teacher.",
+    label_name:"YOUR NAME", name_placeholder:"e.g. Emma",
+    label_grade:"GRADE", label_subject:"SUBJECT", label_teacher:"TEACHER",
+    label_progress:"YOUR PROGRESS", label_topic:"TOPIC", label_depth:"DEPTH",
+    depth_quick:"Quick · 8 turns", depth_standard:"Standard · 12 turns", depth_deep:"Deep · 16 turns",
+    lets_go:"Let's Go", start_session:"Start Session", switch_student:"Switch student",
+    welcome_back:n=>"Welcome back, "+n+"!",
+    welcome_sub:(g,s,n)=>g+" · "+s+" · "+n+" sessions completed",
+    no_topics_yet:"No topics studied yet",
+    sessions_completed:"sessions completed",
+  }
+};
+let curLang = localStorage.getItem("tfLang") || "en";
+function tr(k){ return (I18N[curLang] && I18N[curLang][k]) || (I18N.en[k]) || k; }
+
+const GRADE_DATA = [
+  {v:"小6",ja:"小学6年",en:"Grade 6",available:true},
+  {v:"小1",ja:"小学1年",en:"Grade 1"},{v:"小2",ja:"小学2年",en:"Grade 2"},
+  {v:"小3",ja:"小学3年",en:"Grade 3"},{v:"小4",ja:"小学4年",en:"Grade 4"},
+  {v:"小5",ja:"小学5年",en:"Grade 5"},
+  {v:"中1",ja:"中学1年",en:"Jr High 1"},{v:"中2",ja:"中学2年",en:"Jr High 2"},{v:"中3",ja:"中学3年",en:"Jr High 3"},
+  {v:"高1",ja:"高校1年",en:"High 1"},{v:"高2",ja:"高校2年",en:"High 2"},{v:"高3",ja:"高校3年",en:"High 3"},
+];
+const SUBJECT_DATA = [
+  {v:"算数",ja:"算数",en:"Math",available:true},
+  {v:"国語",ja:"国語",en:"Japanese"},{v:"理科",ja:"理科",en:"Science"},
+  {v:"社会",ja:"社会",en:"Social Studies"},{v:"英語",ja:"英語",en:"English"},
+];
+function fillGradeSubject(l){
+  const cs = l==="ja" ? "（近日対応）" : " (coming soon)";
+  [["gradeInput",GRADE_DATA],["subjectInput",SUBJECT_DATA]].forEach(([id,data])=>{
+    const sel = document.getElementById(id);
+    const prev = sel.value;
+    sel.innerHTML = "";
+    data.forEach(d=>{
+      const o = document.createElement("option");
+      o.value = d.v;
+      o.textContent = d[l] + (d.available ? "" : cs);
+      if(!d.available) o.disabled = true;
+      sel.appendChild(o);
+    });
+    if(prev) sel.value = prev;
+  });
+}
+function refreshTopicLabels(l){
+  const topicSel = document.getElementById("topicSelect");
+  if(!topicSel) return;
+  Array.from(topicSel.options).forEach(o=>{
+    if(o.dataset.ja) o.textContent = l==="ja" ? o.dataset.ja : o.dataset.en;
+  });
+}
+function applyLang(l){
+  curLang = l;
+  localStorage.setItem("tfLang", l);
+  document.documentElement.lang = l;
+  document.querySelectorAll("[data-i18n]").forEach(el=>{
+    const k = el.getAttribute("data-i18n");
+    if(I18N[l] && I18N[l][k]) el.textContent = I18N[l][k];
+  });
+  document.querySelectorAll("[data-i18n-placeholder]").forEach(el=>{
+    const k = el.getAttribute("data-i18n-placeholder");
+    if(I18N[l] && I18N[l][k]) el.placeholder = I18N[l][k];
+  });
+  const b = document.getElementById("langbtn");
+  if(b) b.textContent = (l==="ja") ? "EN" : "JA";
+  fillGradeSubject(l);
+  refreshTopicLabels(l);
+  // Re-render dynamic welcome strings if visible
+  const wel = document.getElementById("welcome");
+  if(wel && wel.style.display !== "none" && window._lastProfile){
+    showWelcome(window._lastProfile);
+  }
+}
+function toggleLang(){ applyLang(curLang==="ja" ? "en" : "ja"); }
 
 // Check for saved profile
 const savedId = localStorage.getItem("tfStudentId");
@@ -217,17 +307,18 @@ async function loadProfile(sid){
 }
 
 function showWelcome(profile){
+  window._lastProfile = profile;
   document.getElementById("onboard").style.display = "none";
   document.getElementById("welcome").style.display = "block";
-  document.getElementById("welcomeMsg").textContent = "Welcome back, "+profile.name+"!";
-  document.getElementById("welcomeSub").textContent = profile.grade+" · "+profile.subject+" · "+profile.sessions_completed+" sessions completed";
+  document.getElementById("welcomeMsg").textContent = tr("welcome_back")(profile.name);
+  document.getElementById("welcomeSub").textContent = tr("welcome_sub")(profile.grade, profile.subject, profile.sessions_completed);
 
   // Proficiency chips
   const grid = document.getElementById("profGrid");
   grid.innerHTML = "";
   const profs = profile.proficiency || {};
   if(Object.keys(profs).length === 0){
-    grid.innerHTML = '<span class="prof-chip">No topics studied yet</span>';
+    grid.innerHTML = '<span class="prof-chip">'+tr("no_topics_yet")+'</span>';
   } else {
     for(const [topic, score] of Object.entries(profs)){
       const label = TOPIC_TX[topic] || topic;
@@ -243,9 +334,11 @@ function showWelcome(profile){
   topicSel.innerHTML = "";
   fetch("/api/topics?grade="+encodeURIComponent(profile.grade)+"&subject="+encodeURIComponent(profile.subject))
     .then(r=>r.json()).then(d=>{
-      (d.topics||[]).forEach(t=>{
-        const o=document.createElement("option");o.value=t;
-        o.textContent=TOPIC_TX[t]||t;
+      (d.topics||[]).forEach(tp=>{
+        const o=document.createElement("option");o.value=tp;
+        o.textContent = curLang==="ja" ? tp : (TOPIC_TX[tp]||tp);
+        o.dataset.ja = tp;
+        o.dataset.en = TOPIC_TX[tp]||tp;
         topicSel.appendChild(o);
       });
     });
@@ -294,6 +387,8 @@ function goToSession(profile, teacherId){
         "&depth=standard";
     });
 }
+
+applyLang(curLang);
 
 function resetProfile(){
   localStorage.removeItem("tfStudentId");

--- a/training_field/web/templates/learn_session.html
+++ b/training_field/web/templates/learn_session.html
@@ -50,6 +50,13 @@ body{
   transition:background .2s;
 }
 .header-back:hover{background:var(--surface-2)}
+.header-lang{
+  color:var(--text);background:var(--surface);text-decoration:none;
+  font-size:12px;font-weight:600;letter-spacing:0.04em;
+  padding:7px 12px;border:1px solid var(--border-strong);border-radius:var(--radius-pill);
+  cursor:pointer;font-family:inherit;transition:background .2s;
+}
+.header-lang:hover{background:var(--surface-2)}
 .header-info{flex:1;display:flex;align-items:center;gap:12px}
 /* Avatar placeholder (future: animated speaking image) */
 .teacher-avatar{
@@ -90,6 +97,15 @@ body{
 .bubble.teacher{
   background:var(--teacher-bg);color:var(--teacher-fg);
   border-radius:var(--radius-lg) var(--radius-lg) var(--radius-lg) 6px;
+}
+.question-box{
+  display:block;margin-top:12px;padding:14px 18px;
+  background:var(--surface);border:2px solid var(--link);
+  border-radius:12px;font-weight:600;font-size:15px;line-height:1.5;
+  color:var(--text);
+}
+:root[data-theme="dark"] .question-box{
+  background:var(--surface-2);border-color:var(--link);
 }
 .bubble.student{
   background:var(--student-bg);color:var(--student-fg);
@@ -143,6 +159,20 @@ body{
 }
 .input-field:focus{border-color:var(--text)}
 .input-field::placeholder{color:var(--muted)}
+.mic-btn{
+  width:48px;height:48px;border-radius:50%;
+  border:none;background:var(--surface);color:var(--muted);
+  font-size:18px;cursor:pointer;display:flex;align-items:center;justify-content:center;
+  border:1px solid var(--border-strong);
+  transition:all .2s var(--ease);
+}
+.mic-btn:hover{background:var(--surface-2);color:var(--text)}
+.mic-btn.listening{
+  background:#ef4444;color:#fff;border-color:#ef4444;
+  animation:mic-pulse 1.2s ease-in-out infinite;
+}
+@keyframes mic-pulse{0%,100%{box-shadow:0 0 0 0 rgba(239,68,68,0.3)}50%{box-shadow:0 0 0 10px rgba(239,68,68,0)}}
+.mic-btn.unsupported{display:none}
 .send-btn{
   width:48px;height:48px;border-radius:50%;
   border:none;background:var(--text);color:var(--bg);
@@ -159,7 +189,7 @@ body{
 <script>(function(){var t=localStorage.getItem("tfTheme")||"light";document.documentElement.setAttribute("data-theme",t);})();</script>
 
 <div class="header">
-  <a href="/learn" class="header-back">← Back</a>
+  <a href="/learn" class="header-back" data-i18n="back">← Back</a>
   <div class="header-info">
     <div class="teacher-avatar" id="tAvatar">—</div>
     <div>
@@ -168,14 +198,18 @@ body{
     </div>
   </div>
   <div class="status-dot" id="statusDot"></div>
+  <button class="header-lang" id="langbtn" onclick="toggleLang()">JA</button>
 </div>
 
 <div class="chat" id="chat"></div>
 
 <div class="input-bar" id="inputBar">
-  <input type="text" class="input-field" id="inputField" placeholder="Type your answer..."
+  <input type="text" class="input-field" id="inputField" placeholder="Type your answer..." data-i18n-placeholder="input_placeholder"
     autocomplete="off" disabled
     onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();sendResponse();}">
+  <button class="mic-btn" id="micBtn" onclick="toggleMic()" title="Voice input">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg>
+  </button>
   <button class="send-btn" id="sendBtn" onclick="sendResponse()" disabled>
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
   </button>
@@ -191,6 +225,72 @@ const TOPIC = params.get("topic") || "分数のかけ算とわり算";
 const DEPTH = params.get("depth") || "standard";
 const GRADE = localStorage.getItem("tfStudentGrade") || "小6";
 const SUBJECT = localStorage.getItem("tfStudentSubject") || "算数";
+
+const I18N = {
+  ja: {
+    back:"← 戻る",
+    input_placeholder:"答えを入力してください...",
+    phase_check:"確認", phase_review:"振り返り",
+    complete_title:"セッション完了",
+    complete_points:"ポイント",
+    complete_sub:(name,prof)=>"よくできました、"+name+"さん！現在の習熟度は "+prof+" です。",
+    continue_learning:"学習を続ける",
+    pre_test:"事前テスト", post_test:"事後テスト",
+    questions_improved:n=>n+" 問改善しました！",
+    pre_test_questions:"事前テスト問題",
+    post_test_questions:"事後テスト問題",
+    your_answer:"あなたの回答：",
+    key_moments:"重要な学びの瞬間",
+    turn_label:"ターン",
+    error_prefix:"エラー：",
+  },
+  en: {
+    back:"← Back",
+    input_placeholder:"Type your answer...",
+    phase_check:"Check", phase_review:"Review",
+    complete_title:"Session Complete",
+    complete_points:"points",
+    complete_sub:(name,prof)=>"Well done, "+name+"! Your proficiency is now at "+prof+".",
+    continue_learning:"Continue Learning",
+    pre_test:"PRE-TEST", post_test:"POST-TEST",
+    questions_improved:n=>"+"+n+" questions improved!",
+    pre_test_questions:"PRE-TEST QUESTIONS",
+    post_test_questions:"POST-TEST QUESTIONS",
+    your_answer:"Your answer: ",
+    key_moments:"KEY LEARNING MOMENTS",
+    turn_label:"Turn",
+    error_prefix:"Error: ",
+  }
+};
+let curLang = localStorage.getItem("tfLang") || "en";
+function t(k){ return (I18N[curLang] && I18N[curLang][k]) || (I18N.en[k]) || k; }
+function applyLang(l){
+  curLang = l;
+  localStorage.setItem("tfLang", l);
+  document.documentElement.lang = l;
+  document.querySelectorAll("[data-i18n]").forEach(el=>{
+    const k = el.getAttribute("data-i18n");
+    if(I18N[l] && I18N[l][k]) el.textContent = I18N[l][k];
+  });
+  document.querySelectorAll("[data-i18n-placeholder]").forEach(el=>{
+    const k = el.getAttribute("data-i18n-placeholder");
+    if(I18N[l] && I18N[l][k]) el.placeholder = I18N[l][k];
+  });
+  const b = document.getElementById("langbtn");
+  if(b) b.textContent = (l==="ja") ? "EN" : "JA";
+}
+function toggleLang(){
+  const next = (curLang==="ja") ? "en" : "ja";
+  applyLang(next);
+  document.getElementById("tTopic").textContent = next==="ja" ? TOPIC : (TOPIC_TX[TOPIC] || TOPIC);
+  // Tell the backend so future teacher/judge messages switch language too
+  if(sessionId){
+    fetch("/api/live/"+sessionId+"/lang",{
+      method:"POST",headers:{"Content-Type":"application/json"},
+      body:JSON.stringify({lang: next}),
+    }).catch(()=>{});
+  }
+}
 
 let sessionId = null;
 let studentName = "Student";
@@ -216,6 +316,20 @@ function typeInto(el, text, cps){
 }
 
 // ── Show teacher message ─────────────────────────
+function splitQuestion(text){
+  const lines = text.split("\n");
+  const bodyLines = [];
+  const qLines = [];
+  for(const line of lines){
+    if(line.trim().startsWith("▶")){
+      qLines.push(line.trim().replace(/^▶\s*/, ""));
+    } else {
+      bodyLines.push(line);
+    }
+  }
+  return { body: bodyLines.join("\n").trim(), question: qLines.join("\n").trim() };
+}
+
 async function showTeacherMsg(text, phaseName){
   const chat = document.getElementById("chat");
   const wrap = document.createElement("div");
@@ -229,7 +343,17 @@ async function showTeacherMsg(text, phaseName){
   wrap.appendChild(bubble);
   chat.appendChild(wrap);
   chat.scrollTop = chat.scrollHeight;
-  await typeInto(bubble, text, 70);
+
+  const { body, question } = splitQuestion(text);
+  if(body){
+    await typeInto(bubble, body, 70);
+  }
+  if(question){
+    const qBox = document.createElement("span");
+    qBox.className = "question-box";
+    bubble.appendChild(qBox);
+    await typeInto(qBox, question, 70);
+  }
 }
 
 function showStudentMsg(text){
@@ -263,10 +387,10 @@ function showComplete(delta, finalProf){
   const card = document.createElement("div");
   card.className = "complete-card";
   card.innerHTML = '<div class="complete-mark">✓</div>'+
-    '<div class="complete-title">Session Complete</div>'+
-    '<div class="complete-delta">'+(delta>=0?"+":"")+delta+' points</div>'+
-    '<div class="complete-sub">Well done, '+studentName+'! Your proficiency is now at '+finalProf+'.</div>'+
-    '<a href="/learn" class="complete-btn">Continue Learning</a>';
+    '<div class="complete-title">'+t("complete_title")+'</div>'+
+    '<div class="complete-delta">'+(delta>=0?"+":"")+delta+' '+t("complete_points")+'</div>'+
+    '<div class="complete-sub">'+t("complete_sub")(studentName, finalProf)+'</div>'+
+    '<a href="/learn" class="complete-btn">'+t("continue_learning")+'</a>';
   chat.appendChild(card);
   chat.scrollTop = chat.scrollHeight;
 }
@@ -283,12 +407,12 @@ async function initSession(){
   } catch(e){}
 
   // Header
-  const t = TEACHERS.find(x=>x.teacher_id===TEACHER_ID) || {};
-  teacherName = t.name || "Teacher";
+  const tConfig = TEACHERS.find(x=>x.teacher_id===TEACHER_ID) || {};
+  teacherName = tConfig.name || "Teacher";
   const initials = (teacherName).replace(/[^A-Za-z]/g,"").slice(0,2).toUpperCase() || "T";
   document.getElementById("tAvatar").textContent = initials;
   document.getElementById("tLabel").textContent = teacherName;
-  document.getElementById("tTopic").textContent = TOPIC_TX[TOPIC] || TOPIC;
+  document.getElementById("tTopic").textContent = curLang==="ja" ? TOPIC : (TOPIC_TX[TOPIC] || TOPIC);
 
   // Start live session
   document.getElementById("statusDot").className = "status-dot active";
@@ -297,14 +421,14 @@ async function initSession(){
       method:"POST",headers:{"Content-Type":"application/json"},
       body:JSON.stringify({
         teacher_id: TEACHER_ID, topic: TOPIC, depth: DEPTH,
-        grade: GRADE, subject: SUBJECT, lang: "en",
+        grade: GRADE, subject: SUBJECT, lang: curLang,
         student_name: studentName,
       }),
     });
     const d = await res.json();
     if(!res.ok) throw new Error(d.detail||"start failed");
     sessionId = d.session_id;
-    showPhase("Check");
+    showPhase(t("phase_check"));
     await showTeacherMsg(d.teacher_message);
     // Enable input
     document.getElementById("inputField").disabled = false;
@@ -331,17 +455,17 @@ function showReview(d){
 
   let reviewHTML = '<div class="complete-card" style="max-width:520px;text-align:left">';
   reviewHTML += '<div class="complete-mark" style="text-align:center">✓</div>';
-  reviewHTML += '<div class="complete-title" style="text-align:center">Session Complete</div>';
+  reviewHTML += '<div class="complete-title" style="text-align:center">'+t("complete_title")+'</div>';
 
   // Score comparison
   reviewHTML += '<div style="display:flex;justify-content:center;gap:40px;margin:24px 0">';
-  reviewHTML += '<div style="text-align:center"><div style="font-size:11px;color:var(--muted);margin-bottom:4px">PRE-TEST</div><div style="font-size:28px;font-weight:600">'+preScore+'</div></div>';
+  reviewHTML += '<div style="text-align:center"><div style="font-size:11px;color:var(--muted);margin-bottom:4px">'+t("pre_test")+'</div><div style="font-size:28px;font-weight:600">'+preScore+'</div></div>';
   reviewHTML += '<div style="text-align:center;padding-top:18px;color:var(--muted)">→</div>';
-  reviewHTML += '<div style="text-align:center"><div style="font-size:11px;color:var(--muted);margin-bottom:4px">POST-TEST</div><div style="font-size:28px;font-weight:600;color:var(--success)">'+postScore+'</div></div>';
+  reviewHTML += '<div style="text-align:center"><div style="font-size:11px;color:var(--muted);margin-bottom:4px">'+t("post_test")+'</div><div style="font-size:28px;font-weight:600;color:var(--success)">'+postScore+'</div></div>';
   reviewHTML += '</div>';
 
   if(improvement > 0){
-    reviewHTML += '<div style="text-align:center;font-size:14px;color:var(--success);margin-bottom:24px">+'+improvement+' questions improved!</div>';
+    reviewHTML += '<div style="text-align:center;font-size:14px;color:var(--success);margin-bottom:24px">'+t("questions_improved")(improvement)+'</div>';
   }
 
   // Detailed Q&A review
@@ -356,7 +480,7 @@ function showReview(d){
       const color = q.correct ? "var(--success)" : "var(--muted)";
       h += '<div style="padding:12px 0;border-bottom:1px solid var(--border)">';
       h += '<div style="font-size:13px;font-weight:500;margin-bottom:4px">Q'+(i+1)+': '+escHtml(q.question)+'</div>';
-      h += '<div style="font-size:12px;color:var(--text-secondary)">Your answer: '+escHtml(q.student_answer)+'</div>';
+      h += '<div style="font-size:12px;color:var(--text-secondary)">'+t("your_answer")+escHtml(q.student_answer)+'</div>';
       h += '<div style="font-size:12px;color:'+color+';margin-top:2px">'+mark+' '+(q.explanation||"")+'</div>';
       h += '</div>';
     });
@@ -364,23 +488,23 @@ function showReview(d){
     return h;
   }
 
-  reviewHTML += renderTest("PRE-TEST QUESTIONS", pre);
-  reviewHTML += renderTest("POST-TEST QUESTIONS", post);
+  reviewHTML += renderTest(t("pre_test_questions"), pre);
+  reviewHTML += renderTest(t("post_test_questions"), post);
 
   // Key learning moments
   const moments = d.key_moments || [];
   if(moments.length > 0){
-    reviewHTML += '<div style="margin-top:24px"><div style="font-size:11px;font-weight:600;color:var(--muted);letter-spacing:0.04em;margin-bottom:10px">KEY LEARNING MOMENTS</div>';
+    reviewHTML += '<div style="margin-top:24px"><div style="font-size:11px;font-weight:600;color:var(--muted);letter-spacing:0.04em;margin-bottom:10px">'+t("key_moments")+'</div>';
     moments.forEach(m=>{
       reviewHTML += '<div style="padding:10px 0;border-bottom:1px solid var(--border);font-size:12px">';
-      reviewHTML += '<div style="color:var(--success);font-weight:500">'+m.phase+' · Turn '+m.turn+' · Δ +'+m.delta+'</div>';
+      reviewHTML += '<div style="color:var(--success);font-weight:500">'+m.phase+' · '+t("turn_label")+' '+m.turn+' · Δ +'+m.delta+'</div>';
       reviewHTML += '<div style="color:var(--text-secondary);margin-top:2px">'+escHtml(m.summary)+'</div>';
       reviewHTML += '</div>';
     });
     reviewHTML += '</div>';
   }
 
-  reviewHTML += '<div style="text-align:center;margin-top:28px"><a href="/learn" class="complete-btn">Continue Learning</a></div>';
+  reviewHTML += '<div style="text-align:center;margin-top:28px"><a href="/learn" class="complete-btn">'+t("continue_learning")+'</a></div>';
   reviewHTML += '</div>';
 
   const card = document.createElement("div");
@@ -405,7 +529,7 @@ async function sendResponse(){
   try {
     const res = await fetch("/api/live/"+sessionId+"/respond",{
       method:"POST",headers:{"Content-Type":"application/json"},
-      body:JSON.stringify({text}),
+      body:JSON.stringify({text, lang: curLang}),
     });
     const d = await res.json();
     if(!res.ok) throw new Error(d.detail||"respond failed");
@@ -427,7 +551,7 @@ async function sendResponse(){
         lastPhase = d.phase;
       }
       if(d.session_phase === "post_test" && lastSessionPhase !== "post_test"){
-        showPhase("Review");
+        showPhase(t("phase_review"));
       }
       lastSessionPhase = d.session_phase;
       await showTeacherMsg(d.teacher_message);
@@ -437,12 +561,60 @@ async function sendResponse(){
       document.getElementById("statusDot").className = "status-dot";
     }
   } catch(e){
-    showTeacherMsg("⚠ "+e.message);
+    showTeacherMsg("⚠ "+t("error_prefix")+e.message);
     input.disabled = false;
     document.getElementById("sendBtn").disabled = false;
   }
 }
 
+// ── Voice input (Web Speech API) ─────────────────
+const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+let recognition = null;
+let isListening = false;
+
+function initMic(){
+  const btn = document.getElementById("micBtn");
+  if(!SpeechRecognition){ btn.classList.add("unsupported"); return; }
+  recognition = new SpeechRecognition();
+  recognition.continuous = false;
+  recognition.interimResults = true;
+  recognition.lang = curLang === "ja" ? "ja-JP" : "en-US";
+
+  recognition.onresult = (e) => {
+    const input = document.getElementById("inputField");
+    let transcript = "";
+    for(let i = 0; i < e.results.length; i++){
+      transcript += e.results[i][0].transcript;
+    }
+    input.value = transcript;
+  };
+  recognition.onend = () => {
+    isListening = false;
+    btn.classList.remove("listening");
+  };
+  recognition.onerror = (e) => {
+    isListening = false;
+    btn.classList.remove("listening");
+  };
+}
+
+function toggleMic(){
+  if(!recognition) return;
+  const btn = document.getElementById("micBtn");
+  if(isListening){
+    recognition.stop();
+    isListening = false;
+    btn.classList.remove("listening");
+  } else {
+    recognition.lang = curLang === "ja" ? "ja-JP" : "en-US";
+    recognition.start();
+    isListening = true;
+    btn.classList.add("listening");
+  }
+}
+
+initMic();
+applyLang(curLang);
 initSession();
 </script>
 </body>


### PR DESCRIPTION
## 概要 / Summary
セッションの学習体験を広範に改善し、新機能「Teacher Memory」（セッション間の学び）を追加します。

## なぜ / Why
実際に使って分かった課題の集合的な解消：
- 出題と解説が視覚的に混ざり分かりにくい
- Judge が厳しすぎて正解なのに不正解判定される
- Teacher が回りくどいソクラテス式になる場面がある
- JP選択しても Session画面で翻訳されない箇所がある
- Grade/科目セレクタが表示上は多彩だが、実体は小6算数のみ
- Teacher Agent がセッション毎に「記憶喪失」状態で起動する

## 変更内容 / Changes

### UI / UX
- Grade/科目セレクタを小6算数のみ選択可能に（他は \"coming soon\" で明示）
- Dashboard の Observatory / Start Learning ポータルカードを翻訳対応
- Teacher の発言内の質問を \`▶\` マーカーで識別し、青枠の質問ボックスとして視覚分離
- セッション画面に音声入力ボタン（Web Speech API、外部依存なし）

### i18n
- \`/learn\`（オンボーディング）: ラベル、プレースホルダ、Welcome Back 動的文言すべて JA/EN 対応
- \`/learn/session\`: ヘッダ、フェーズ、完了カード、レビューカード、Key Learning Moments すべて JA/EN 対応
- セッション途中の言語切替: \`POST /api/live/{id}/lang\` で バックエンド側の \`session.lang\` を即時更新
- 言語切替時の \"coming soon\" サフィックスも正しく切替

### プロンプト品質
- Teacher: \`edu6th_math.md\` と矛盾していた \"Never give the direct answer\" を削除。直接教える方針に修正
- Judge: 形式に寛容に（\"70\" を \"70度\" として正解扱い、\"1/2\"=\"0.5\"、単位省略など）。先に自分で計算してから比較する手順に変更
- Test: 1文・前置きなし・\`▶\` プレフィックス
- 全プロンプトで LaTeX 禁止（\`\\frac\`, \`\\times\` など）

### ✨ 新機能: Teacher Memory（セッション間の学び）
- 新規ファイル: \`training_field/teacher_memory.py\`
- 各セッション終了時に Referee の directive・メトリクスを抽出し、\`field/teacher_memory/{teacher_id}.json\` に保存（最新5件保持）
- 次セッション開始時に \`load_teacher()\` がメモリ読み込み → \`_build_system_prompt()\` が \"LESSONS FROM PAST SESSIONS\" ブロックとしてシステムプロンプトに自動注入
- 3箇所の保存フロー（live、batch、streaming）すべてにフック

アーキテクチャ原則: \`TeacherConfig\`（人格）は不変、\`Memory\`（経験）は別JSONに蓄積。

## 動作確認 / Testing
- [x] ローカルサーバーで Live セッションを通しで実行（pre-test → teaching → post-test → review）
- [x] JP/EN 切替がすべての画面で機能
- [x] 音声入力が Chrome で動作（JA/EN 切替も追従）
- [x] 正解形式緩和を実データで確認（\"1/2\" for 2/3 × 3/4）
- [x] セッション完了で \`field/teacher_memory/t001.json\` が生成されることを確認
- [x] 次セッション起動時のシステムプロンプトに \"LESSONS FROM PAST SESSIONS\" が入ることをユニットテストで確認

## レビュアーへの注意 / Notes for Reviewer
- 変更範囲が広いため、レビューは「UI/プロンプト/メモリ」の3テーマに分けて見ると分かりやすいです
- 未コミットの \`fix_*.py\`, \`make_web.py\` は本PRの対象外（旧ツーリング）