### PR TITLE
Teacher clarity + session progress indicators

### DIFF
--- a/training_field/teacher_agent.py
+++ b/training_field/teacher_agent.py
@@ -91,6 +91,25 @@ class TeacherAgent:
 - Do NOT ask vague open-ended questions like "What do you think?" or "How would you approach this?"
 - Keep it conversational and encouraging, never lecturing.
 
+=== RESPONDING TO STUDENT ANSWERS (VERY IMPORTANT) ===
+When the student gives a calculation answer, IMMEDIATELY compute the correct answer yourself
+and compare. Then open with a clear verdict — never ambiguous.
+- If CORRECT (value matches, any equivalent form):
+  - Open with a crisp affirmation: "正解！" / "その通り！" / "Correct!"
+  - Briefly confirm the method (1 sentence), then present the next step.
+- If WRONG:
+  - Open with a friendly but unambiguous correction:
+    "ちょっと違うね。" / "惜しい！" / "Not quite — let's look at this."
+  - State the CORRECT answer and show the one key step where the student went off.
+  - Then offer a similar retry problem.
+- If PARTIALLY correct (right method, arithmetic slip):
+  - "考え方はOK！でも計算のここだけ…" / "Right method, small slip in…"
+BANNED PHRASES — never use these in response to a student's answer (they feel sarcastic when
+the student was actually wrong):
+  - "面白い意見ですね" / "興味深い答えですね" / "なるほど" (as a first reaction)
+  - "Interesting answer" / "That's interesting"
+  - Any phrase that praises before grading.
+
 {memory_block}
 === YOUR TEACHING IDENTITY ===
 Philosophy: {self.config.teaching_philosophy}

--- a/training_field/web/templates/learn_session.html
+++ b/training_field/web/templates/learn_session.html
@@ -68,11 +68,44 @@ body{
 }
 .teacher-label{font-size:15px;font-weight:600;letter-spacing:-0.015em}
 .teacher-topic{font-size:12px;color:var(--muted)}
+.progress-pill{
+  display:none;align-items:center;gap:10px;
+  padding:5px 12px;margin-left:auto;
+  background:var(--surface-2);border:1px solid var(--border);
+  border-radius:var(--radius-pill);
+  font-size:11px;color:var(--muted);font-feature-settings:"tnum";font-weight:500;
+  white-space:nowrap;
+}
+.progress-pill.visible{display:inline-flex}
+.progress-pill strong{color:var(--text);font-weight:600}
+.progress-pill .progress-sep{opacity:0.4}
 .status-dot{
   width:8px;height:8px;border-radius:50%;background:var(--muted);
-  margin-left:auto;flex-shrink:0;transition:background .3s;
+  flex-shrink:0;transition:background .3s;
 }
 .status-dot.active{background:var(--success);animation:blink 1.4s infinite}
+
+/* Milestone card (every N teaching turns) */
+.milestone-card{
+  max-width:520px;margin:12px auto;
+  padding:16px 20px;background:var(--surface);
+  border:1px solid var(--border);border-radius:var(--radius-md);
+  display:flex;align-items:center;gap:14px;
+  box-shadow:var(--shadow-sm);animation:fadeUp .3s var(--ease);
+}
+.milestone-icon{font-size:24px;flex-shrink:0}
+.milestone-body{flex:1;font-size:13px;line-height:1.5;color:var(--text)}
+.milestone-body strong{color:var(--text);font-weight:600}
+.milestone-actions{display:flex;gap:8px;flex-shrink:0}
+.milestone-btn{
+  padding:6px 14px;font-size:12px;font-weight:500;font-family:inherit;
+  background:var(--surface);color:var(--text);
+  border:1px solid var(--border-strong);border-radius:var(--radius-pill);
+  cursor:pointer;transition:all .15s var(--ease);
+}
+.milestone-btn:hover{background:var(--surface-2)}
+.milestone-btn.primary{background:var(--text);color:var(--bg);border-color:var(--text)}
+.milestone-btn.primary:hover{opacity:0.85}
 @keyframes blink{0%,100%{opacity:1}50%{opacity:.4}}
 
 /* ── Chat ─────────────────────────────────────── */
@@ -272,6 +305,11 @@ body{
       <div class="teacher-topic" id="tTopic"></div>
     </div>
   </div>
+  <div class="progress-pill" id="progressPill" title="Session progress">
+    <span><span data-i18n="progress_turn">Turn</span> <strong id="progressTurn">0</strong></span>
+    <span class="progress-sep">·</span>
+    <span><strong id="progressTime">0:00</strong></span>
+  </div>
   <div class="status-dot" id="statusDot"></div>
   <button class="header-lang" id="langbtn" onclick="toggleLang()">JA</button>
 </div>
@@ -349,6 +387,12 @@ const I18N = {
     qa_send_explain:"もう一度説明してもらえますか？",
     qa_send_hint:"ヒントをください",
     qa_send_next:"次の問題に進んでください",
+    progress_turn:"ターン",
+    milestone_icon:"🎯",
+    milestone_title:(n)=>n+"ターン続いたよ！順調です。",
+    milestone_sub:"もう少し学んでいく？それとも復習テストに進む？",
+    milestone_continue:"続ける",
+    milestone_end:"テストに進む",
   },
   en: {
     back:"← Back",
@@ -383,6 +427,12 @@ const I18N = {
     qa_send_explain:"Can you explain that again?",
     qa_send_hint:"Give me a hint please.",
     qa_send_next:"Let's move to the next problem.",
+    progress_turn:"Turn",
+    milestone_icon:"🎯",
+    milestone_title:(n)=>"You've talked for "+n+" turns — great job!",
+    milestone_sub:"Keep going or move on to the review test?",
+    milestone_continue:"Keep going",
+    milestone_end:"Go to test",
   }
 };
 let curLang = localStorage.getItem("tfLang") || "en";
@@ -531,6 +581,7 @@ function showPhase(label){
 }
 
 function showComplete(delta, finalProf){
+  stopProgressTracking();
   const chat = document.getElementById("chat");
   document.getElementById("inputBar").style.display = "none";
   document.getElementById("statusDot").className = "status-dot";
@@ -578,6 +629,7 @@ async function initSession(){
     const d = await res.json();
     if(!res.ok) throw new Error(d.detail||"start failed");
     sessionId = d.session_id;
+    startProgressTracking();
     showTestBanner("pre");
     await showTeacherMsg(d.teacher_message, {testKind: "pre", testProgress: d.test_progress});
     // Enable input
@@ -595,7 +647,71 @@ async function initSession(){
 let lastPhase = null;
 let lastSessionPhase = "pre_test";
 
+// ── Progress tracking (Issue #17) ────────────────
+let sessionStartMs = null;
+let teachingTurnCount = 0;
+let progressTimer = null;
+const MILESTONE_EVERY = 5;  // show milestone card every N teaching turns
+let lastMilestoneShownAt = 0;
+
+function startProgressTracking(){
+  sessionStartMs = Date.now();
+  document.getElementById("progressPill").classList.add("visible");
+  updateProgressPill();
+  if(progressTimer) clearInterval(progressTimer);
+  progressTimer = setInterval(updateProgressPill, 1000);
+}
+
+function stopProgressTracking(){
+  if(progressTimer){ clearInterval(progressTimer); progressTimer = null; }
+}
+
+function updateProgressPill(){
+  if(!sessionStartMs) return;
+  const secs = Math.floor((Date.now() - sessionStartMs) / 1000);
+  const m = Math.floor(secs / 60);
+  const s = secs % 60;
+  const mmss = m + ":" + String(s).padStart(2, "0");
+  document.getElementById("progressTime").textContent = mmss;
+  document.getElementById("progressTurn").textContent = teachingTurnCount;
+}
+
+function maybeShowMilestone(){
+  if(lastSessionPhase !== "teaching") return;
+  if(teachingTurnCount === 0) return;
+  if(teachingTurnCount % MILESTONE_EVERY !== 0) return;
+  if(teachingTurnCount === lastMilestoneShownAt) return;
+  lastMilestoneShownAt = teachingTurnCount;
+  showMilestoneCard(teachingTurnCount);
+}
+
+function showMilestoneCard(n){
+  const chat = document.getElementById("chat");
+  const card = document.createElement("div");
+  card.className = "milestone-card";
+  card.innerHTML =
+    '<div class="milestone-icon">'+t("milestone_icon")+'</div>'+
+    '<div class="milestone-body"><strong></strong><div></div></div>'+
+    '<div class="milestone-actions">'+
+      '<button class="milestone-btn" data-action="continue"></button>'+
+      '<button class="milestone-btn primary" data-action="end"></button>'+
+    '</div>';
+  card.querySelector(".milestone-body strong").textContent = t("milestone_title")(n);
+  card.querySelector(".milestone-body div").textContent = t("milestone_sub");
+  const btns = card.querySelectorAll(".milestone-btn");
+  btns[0].textContent = t("milestone_continue");
+  btns[1].textContent = t("milestone_end");
+  btns[0].addEventListener("click", ()=> card.remove());
+  btns[1].addEventListener("click", ()=>{
+    card.remove();
+    endSession();
+  });
+  chat.appendChild(card);
+  chat.scrollTop = chat.scrollHeight;
+}
+
 function showReview(d){
+  stopProgressTracking();
   const chat = document.getElementById("chat");
   document.getElementById("inputBar").style.display = "none";
   document.getElementById("statusDot").className = "status-dot";
@@ -788,11 +904,17 @@ async function finalizeSend(text, bubbleWrap){
       }
       lastSessionPhase = d.session_phase;
       updateQuickActions();
+      // Count teaching turns for progress / milestone
+      if(d.session_phase === "teaching"){
+        teachingTurnCount += 1;
+        updateProgressPill();
+      }
       // Build teacher message options (test badge if in test phase)
       const teacherOpts = {};
       if(d.session_phase === "pre_test") { teacherOpts.testKind = "pre"; teacherOpts.testProgress = d.test_progress; }
       else if(d.session_phase === "post_test") { teacherOpts.testKind = "post"; teacherOpts.testProgress = d.test_progress; }
       await showTeacherMsg(d.teacher_message, teacherOpts);
+      maybeShowMilestone();
       input.disabled = false;
       document.getElementById("sendBtn").disabled = false;
       input.focus();


### PR DESCRIPTION
## 概要 / Summary
実使用で上がった2件を1つのPRで対応します。
- **#16** Teacher の「面白い意見ですね」系の曖昧な返答 → 正誤が明確に伝わるよう修正
- **#17** セッションがいつ終わるか分からずモチベーション続かない → 進捗表示 + 区切りカード

## なぜ / Why
Issue #16 のケースでは、生徒が間違えた時に「その答えは興味深いですね」と言われて皮肉に感じ、学習意欲が下がる事例が発生。
Issue #17 では、無制限セッションで達成感や区切りが見えず、いつ終われば良いのか不安。

## 変更内容 / Changes

### #16 Teacher プロンプトの正誤判定ルール (training_field/teacher_agent.py)
- 生徒の解答を受けたら**まず自分で計算して比較**する手順を明記
- **正解**時: 「正解！」/「Correct!」で明確に肯定、手法を1文確認、次の問題へ
- **不正解**時: 「ちょっと違うね」/「Not quite」で明確に訂正、**正解と要点**を示し、類似問題で再挑戦
- **部分正解**時: 考え方OKを認めた上で具体的なミス位置を指摘
- **禁止フレーズ**: 「面白い意見ですね」「興味深い答えですね」「なるほど」(第一声として) / "Interesting answer" 等を明示的にBANNED扱い

### #17 進捗インジケーター (training_field/web/templates/learn_session.html)
- ヘッダーに「ターン N · M:SS」ピルを追加、1秒ごとに更新
- 授業フェーズ5ターンごとに「🎯 5ターン続いたよ！順調です」のマイルストーンカード
  - カード内ボタン: 「続ける」(カード消す) / 「テストに進む」(End Session呼出)
- Review / Complete / End のタイミングでタイマー停止
- JA/EN 両言語対応

バックエンド変更なし。授業ターン数はサーバーから返される \`session_phase\` 遷移から派生カウント。

## 動作確認 / Testing
- [x] Python / JS 構文チェック
- [x] ローカルで \`/learn/session\` が 200 で返る
- [x] 新要素（progressPill, milestone-card, progressTurn/Time）が描画される
- [ ] 実セッションで正誤判定の文言が明確になっていることを確認
- [ ] 5ターン到達時にマイルストーンカードが出ることを確認
- [ ] ヘッダーの経過時間/ターン数が更新されることを確認

## レビュアーへの注意 / Notes for Reviewer
- \`teacher_agent.py\` のプロンプト変更は LLM 出力の傾向を変えるため、実際のセッションで数回試してから Railway にマージするのが安全
- マイルストーンのしきい値 \`MILESTONE_EVERY = 5\` は定数として分離。数字を調整しやすい

## 関連
Closes #16
Closes #17