### PR TITLE
Session feedback buttons + Teacher Memory visualization + README rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,153 +1,312 @@
 # Toy Alchemy
 
-AIエージェントが「教え方」を学習・実験するプラットフォーム + 子供向けAI家庭教師（LINE Bot）。
+An AI tutor that adapts to how your child thinks — and a lab where we teach AI agents how to teach.
 
-メインの実験場は **Training Field**（`training_field/`）。Railway上で稼働しており、誰でもブラウザから使えます。
+Every child learns differently. Some need a patient coach; others need a formal professor; most need something in between. Toy Alchemy is a playground for parents, teachers, and researchers to explore *what makes an AI a good tutor* — and a live tutor your child can actually use today.
 
-🌐 **本番URL**: https://beyond-answer-engine.up.railway.app
+🌐 **Live app**: https://beyond-answer-engine.up.railway.app
+📚 **Architecture**: [`docs/architecture.md`](./docs/architecture.md)
+📂 **GitHub**: https://github.com/rojoma/toy-alchemy
 
----
-
-## 👥 チームメンバー向けガイド
-
-### 非エンジニアの方へ（daigo, mach）
-
-コードを書かなくても貢献できます。以下の3つだけ覚えてください。
-
-#### 1. 使う
-ブラウザで https://beyond-answer-engine.up.railway.app を開く → そのまま使えます。
-
-| 何をしたい？ | URL |
-|---|---|
-| AIエージェント同士の対話を観察 | トップページ → Observatory |
-| 自分が生徒として学ぶ | トップページ → Start Learning |
-| 過去のセッション履歴を見る | トップページ → View all |
-
-#### 2. フィードバックする
-気になった点があれば GitHub Issue で報告してください。
-👉 https://github.com/rojoma/toy-alchemy/issues/new/choose
-
-| 種類 | テンプレ |
-|---|---|
-| 先生の発言が変、判定がおかしい | 📝 セッションのフィードバック |
-| 先生のキャラを変えたい、新しい先生を作りたい | 👩‍🏫 Teacher調整リクエスト |
-| エラーが出る | 🐛 バグ報告 |
-| 新しい機能がほしい | ✨ 新機能リクエスト |
-
-スクリーンショットや実際の会話のコピペがあると最高に助かります。
-
-#### 3. システムを知る
-全体像はここに書いてあります → [`docs/architecture.md`](./docs/architecture.md)
+MIT MAS.664 AI Studio, Spring 2026 — Team: Toy Alchemy
 
 ---
 
-### エンジニア向け
+## The problem
 
-#### セットアップ
+AI tutors today are answer engines dressed as teachers. They give the right answer fast, praise every response the same way, and forget everything about the student between sessions. For a child, that means:
+
+- **No adaptation.** A 6th-grader who is anxious about fractions and a 6th-grader who is bored by them get the same explanation.
+- **No memory.** The tutor doesn't remember that last week the student almost had it, and just needs one more nudge.
+- **No accountability.** When the tutor says something confusing or flatly wrong, nothing catches it.
+
+Parents and teachers are left with a tool they cannot tune, cannot trust, and cannot see into.
+
+This repo is our attempt to change that. Toy Alchemy treats teaching itself as something an AI has to *earn* — through tunable teaching parameters, persistent per-student memory, and an independent AI evaluator that scores every turn of the conversation.
+
+---
+
+## What it does
+
+- **Choose a teacher** — pick a pre-built persona (Warm Coach, Prof. Tanaka, Ms. Rivera, Cool Mentor) or design your own with tunable parameters.
+- **Learn a topic** — the child works through a three-phase session: pre-check test → guided teaching → post-check test.
+- **Remember across sessions** — per-student memory records strengths, struggles, and emotional notes so the next session picks up where the last one left off.
+- **Evaluate every turn** — a separate *Principal* agent (the "referee") scores each teacher response on six research-backed dimensions and feeds a directive back to the teacher for the next turn.
+- **Observe two AIs teach each other** — the Observatory lets you watch a teacher agent instruct a student agent, live, with the Principal's scores overlaid.
+- **Give feedback** — parents, students, and observers can flag issues directly to GitHub Issues from within the app.
+
+---
+
+## How the Teacher is designed
+
+A teacher in Toy Alchemy is not a single prompt. It is a **TeacherConfig** — a set of parameters that shape behavior across every turn of a session.
+
+```python
+@dataclass
+class TeacherConfig:
+    name: str
+    teaching_philosophy: str             # one-line credo shown to the model every turn
+    warmth: float                        # 0.0 cool / 0.8 warm
+    formality: float                     # 0.3 casual / 0.85 professor-like
+    verbosity: float                     # how much the teacher talks per turn
+    patience_threshold: int              # how many wrong tries before shifting strategy
+    scaffolding_decay_rate: float        # how quickly hints get reduced as mastery grows
+    prior_knowledge_assumption: float    # what the teacher assumes the student already knows
+    error_response_style: str            # "reframe" | "decompose" | "redirect"
+    frustration_handling: str            # "encourage" | "slow_down" | "redirect"
+    motivation_style: str                # "challenge" | "encouragement" | "mastery"
+    metacognitive_prompting: bool        # asks "how did you think about this?"
+    pacing_speed: float                  # overall session tempo
+    selected_skills: list[str]           # ["socratic_questioning", "concrete_examples", ...]
+```
+
+Each parameter maps to real pedagogy. `warmth` changes the emotional register. `patience_threshold` controls when the teacher backs off from a struggling student. `selected_skills` pulls in one or more skill cards (`field/skills/*.md`) — modular techniques such as Socratic questioning, stepwise decomposition, concrete examples, error reframing, or metacognitive prompting — and splices them into the system prompt.
+
+Three design consequences:
+
+1. **Tunable without code.** Every external teacher lives as a single JSON file in `field/external_teachers/` (see [`warm_v1.json`](./training_field/field/external_teachers/warm_v1.json), [`prof_tanaka.json`](./training_field/field/external_teachers/prof_tanaka.json)). A non-engineer can copy one, change `warmth` from 0.9 to 0.4, and ship a new teacher.
+2. **Comparable.** Two teachers differ in a finite, named space — so we can ask "does higher warmth actually help anxious learners?" rather than hand-waving about "tone."
+3. **Inspectable.** The [`Teacher Memory`](./training_field/teacher_memory.py) panel shows what the teacher has noticed about a specific student so far. Nothing is hidden.
+
+---
+
+## How the Referee evaluates every turn
+
+After each teacher–student exchange, a separate agent — the **Principal** (`training_field/referee_agent.py`) — reads the exchange and returns structured JSON. It has no loyalty to the teacher. Its only loyalty is the student's learning.
+
+The Principal's rubric is grounded in established educational theory:
+
+| Signal | Weight | What it captures | Grounded in |
+|---|---|---|---|
+| ZPD alignment | 25% | Is the challenge in the student's Zone of Proximal Development? | Vygotsky |
+| Scaffolding quality | 20% | Are supports given at the right moment, the right size? | Wood, Bruner & Ross |
+| Factual accuracy | 20% | Is what the teacher said actually correct? | Hallucination guard |
+| Motivation climate | 15% | Does the student feel safer / more curious after this turn? | Self-Determination Theory, Dweck |
+| Clarity | 10% | Would a 6th-grader understand this? | — |
+| Frustration response | 10% | When the student showed frustration, did the teacher help? | Kapur (productive failure) |
+
+```python
+overall_score = sum(weight * signal for weight, signal in RUBRIC_WEIGHTS.items())
+```
+
+The Principal also returns side channels that shape the next turn:
+
+- **`directive_to_teacher`** — a one-line instruction the teacher will see *before* generating its next response. (This is how the teacher actually improves mid-session.)
+- **`hallucination_detected`** — a hard flag; a true value overrides the overall score.
+- **`answer_given_directly`** — flags when the teacher short-circuited the learning by just giving the answer.
+- **`understanding_delta`** — estimated change in student understanding this turn (−5 to +10).
+
+**Why this matters:** teaching quality becomes a measured, decomposed signal instead of a gut feeling. Two teachers can be compared not just by overall score but by *which dimension* they win on — and the student gets the benefit of an evaluator watching over their shoulder every turn.
+
+---
+
+## Live app
+
+Open https://beyond-answer-engine.up.railway.app to:
+
+- **Start Learning** — pick a teacher, pick a topic, run a 3-phase session.
+- **Observatory** — watch two AI agents (teacher + simulated student) teach each other, with Principal scores overlaid live.
+- **View all sessions** — browse past sessions, see transcripts and scores.
+- **Teacher Memory** — inspect what a teacher has remembered about a specific student.
+
+Seed teachers already loaded: Warm Coach, Prof. Tanaka, Ms. Rivera, Cool Mentor.
+
+---
+
+## Who this is for
+
+- **Parents** — a tutor that adapts to your child, plus a window into *how* it adapts. Feedback you give goes straight into how the teacher behaves next time.
+- **Teachers & educators** — a testbed for "what kind of AI tutor actually helps?" Swap teaching parameters, run a session, read the Principal's rubric scores.
+- **Researchers** — every session produces structured, per-turn evaluation data grounded in Vygotsky/Bloom/Dweck. Useful for studying teaching strategies in a controlled setting.
+- **Engineers & contributors** — see below.
+
+---
+
+## Quick start (local)
 
 ```bash
-# 1. クローン
+# 1. Clone
 git clone https://github.com/rojoma/toy-alchemy.git
 cd toy-alchemy
 
-# 2. Python仮想環境
+# 2. Python virtual env
 python -m venv .venv
-source .venv/bin/activate   # Windows: .venv\Scripts\activate
+source .venv/bin/activate       # Windows: .venv\Scripts\activate
 pip install -r training_field/requirements.txt
 
-# 3. 環境変数
+# 3. Environment
 cp .env.example .env
-# .env を開いて OPENAI_API_KEY を設定
+# Open .env and set OPENAI_API_KEY
 
-# 4. サーバー起動
+# 4. Run the server
 uvicorn training_field.web.app:app --port 8765 --host 127.0.0.1 --reload
 ```
 
-ブラウザで http://127.0.0.1:8765 を開く。
+Open http://127.0.0.1:8765 in your browser.
 
-#### LINE Bot 側を動かす場合
+### LINE Bot side (paused)
+
+The LINE Bot front-end (`src/line_bot_server.py`) is **currently paused** — no active development and no live deployment. Code is kept for reference.
+
+<details>
+<summary>Run it locally anyway (at your own risk)</summary>
 
 ```bash
 uvicorn src.line_bot_server:app --reload --port 8000
 ngrok http 8000
-# 表示されたURL/webhook を LINE Developers Console に登録
+# Register the resulting URL/webhook in LINE Developers Console
 ```
 
-`.env` に `LINE_CHANNEL_SECRET`, `LINE_CHANNEL_ACCESS_TOKEN` も追加。
+Add `LINE_CHANNEL_SECRET` and `LINE_CHANNEL_ACCESS_TOKEN` to `.env`.
 
-#### 開発フロー
+</details>
+
+### Run the tests
 
 ```bash
-git checkout main && git pull
-git checkout -b feature/your-task
-# 作業
-git add . && git commit -m "何をしたか"
-git push -u origin feature/your-task
-# GitHubでPR作成 → レビュー → main へマージ
+pytest tests/ -v
 ```
-
-詳細は [`CONTRIBUTING.md`](./CONTRIBUTING.md) を参照。
-
-#### コードを読む順番
-
-1. [`docs/architecture.md`](./docs/architecture.md) — 全体像
-2. `training_field/web/app.py` — APIエンドポイント
-3. `training_field/teacher_agent.py` — Teacher AIの本体
-4. `training_field/referee_agent.py` — 評価エージェント
-5. `training_field/web/templates/` — UI
 
 ---
 
-## 📁 リポジトリ構成
+## Development workflow
+
+```bash
+git checkout main && git pull
+git checkout -b feat/<issue-number>-<short-name>
+# make changes
+git add -p && git commit -m "what you did"
+git push -u origin HEAD
+# open a PR on GitHub, link the issue with "Closes #N"
+```
+
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for details.
+
+### Code reading order
+
+1. [`docs/architecture.md`](./docs/architecture.md) — full picture
+2. [`training_field/web/app.py`](./training_field/web/app.py) — FastAPI endpoints
+3. [`training_field/teacher_agent.py`](./training_field/teacher_agent.py) — Teacher core
+4. [`training_field/referee_agent.py`](./training_field/referee_agent.py) — Principal evaluator
+5. [`training_field/teacher_memory.py`](./training_field/teacher_memory.py) — per-student memory
+6. [`training_field/web/templates/`](./training_field/web/templates/) — UI
+
+---
+
+## Architecture
+
+```
+┌──────────────┐      ┌──────────────────────────┐      ┌──────────────────┐
+│  Browser UI  │◄────►│  FastAPI app (app.py)    │◄────►│ Railway Volume    │
+│ (vanilla JS +│      │  Jinja2 templates        │      │  - teacher_memory │
+│ Web Speech)  │      └────────┬─────────────────┘      │  - session logs   │
+└──────────────┘               │                        │  - reports        │
+                               ▼                        └──────────────────┘
+                    ┌────────────────────┐
+                    │  Agents            │
+                    │  ├─ TeacherAgent   │  parameters + skill cards → LLM
+                    │  ├─ StudentAgent   │  simulated learner (Observatory)
+                    │  └─ PrincipalAgent │  referee, returns rubric JSON
+                    └────────────────────┘
+                               │
+                               ▼
+                    ┌────────────────────┐
+                    │  field/            │
+                    │  ├─ skills/*.md    │  Socratic, stepwise, concrete, ...
+                    │  ├─ external_      │  JSON-defined teachers
+                    │  │  teachers/      │
+                    │  └─ field_contract │
+                    └────────────────────┘
+```
+
+---
+
+## Repository structure
 
 ```
 toy-alchemy/
-├── training_field/         # ★メインの実験場（Railway デプロイ対象）
-│   ├── web/                # FastAPIアプリ
-│   ├── teacher_agent.py    # 教師AI
-│   ├── student_agent.py    # 生徒AI
-│   ├── referee_agent.py    # 審判AI
-│   ├── teacher_memory.py   # セッション間記憶
-│   └── field/              # 教師・スキル定義
-├── src/                    # LINE Bot（旧）
+├── training_field/              ★ main platform (deployed to Railway)
+│   ├── web/                      FastAPI app + templates
+│   ├── teacher_agent.py          Teacher core (TeacherConfig + prompt assembly)
+│   ├── student_agent.py          Simulated student (for Observatory)
+│   ├── referee_agent.py          Principal evaluator (rubric + directive)
+│   ├── teacher_memory.py         Per-student persistent memory
+│   ├── teacher_registry.py       Loads external_teachers/*.json
+│   ├── session_runner.py         Orchestrates a full session
+│   ├── proficiency_model.py      Student proficiency tracking
+│   ├── evaluator.py              Post-session aggregation
+│   └── field/                    Teacher and skill definitions
+│       ├── skills/*.md           Modular teaching techniques
+│       ├── external_teachers/    JSON-defined teachers
+│       └── field_contract.json   What the field guarantees to teachers
+├── src/                          LINE Bot integration (paused — not actively maintained)
 ├── docs/
-│   └── architecture.md     # アーキテクチャドキュメント
-├── tests/                  # テスト
-├── .github/                # PR/Issueテンプレ
-├── CONTRIBUTING.md         # 開発フロー
-├── Procfile / nixpacks.toml # Railway デプロイ設定
+│   └── architecture.md           Full architecture
+├── tests/                        pytest suite
+├── .github/                      PR + Issue templates
+├── CONTRIBUTING.md               Workflow details
+├── Procfile / nixpacks.toml      Railway deploy config
 └── requirements.txt
 ```
 
 ---
 
-## 🚀 デプロイ
+## Deployment
 
-main ブランチへのpushで Railway が自動デプロイ。
+Pushing to `main` triggers an auto-deploy on Railway.
 
-- 設定: `Procfile` (web起動) + `nixpacks.toml` (Pythonビルド)
-- 環境変数は Railway ダッシュボードで管理
-- 永続データ（teacher_memory, reports等）は Railway Volume に保存
-
----
-
-## 🔐 セキュリティ
-
-- `.env` は **絶対にcommitしない**（`.gitignore`済み）
-- APIキーをSlack/チャットに直接貼らない
-- 学習者プロファイル (`reports/students/`) は個人情報相当として扱う
+- `Procfile` boots the web process; `nixpacks.toml` handles the Python build.
+- Env vars are managed in the Railway dashboard.
+- Persistent state (teacher memory, session reports) lives on a Railway Volume.
 
 ---
 
-## 技術スタック
+## Security & privacy
 
-- Python 3.11 / FastAPI / Jinja2
-- OpenAI GPT-4o
-- バニラ JS (フレームワーク無し)
-- Web Speech API (音声入力)
-- Railway (デプロイ)
+- `.env` is never committed (enforced by `.gitignore`).
+- API keys are never pasted into Slack, chat, or PR bodies.
+- Student profiles in `reports/students/` are treated as personal data. Do not share externally without consent.
 
 ---
 
-## ライセンス
-（未設定）
+## Scope & limitations
+
+**In scope today:**
+- Parameter-tunable teacher agents (warmth, formality, patience, skills, …)
+- Modular skill cards (Socratic questioning, stepwise decomposition, concrete examples, error reframing, metacognitive prompting)
+- Six-signal Principal rubric grounded in educational theory
+- Per-student persistent memory across sessions
+- Three-phase sessions (pre-test → teaching → post-test)
+- Observatory mode (teacher ↔ simulated student)
+
+**Not yet:**
+- Photo upload of real homework ([#32](https://github.com/rojoma/toy-alchemy/issues/32))
+- Free-form topic selection by the learner ([#33](https://github.com/rojoma/toy-alchemy/issues/33))
+- Skipping the pre-test when the learner already knows the scope ([#28](https://github.com/rojoma/toy-alchemy/issues/28))
+- End-of-session feedback from the student ([#29](https://github.com/rojoma/toy-alchemy/issues/29))
+- Parent-side tuning controls ([#30](https://github.com/rojoma/toy-alchemy/issues/30) — under discussion)
+- A landing page aimed at first-time visitors ([#31](https://github.com/rojoma/toy-alchemy/issues/31))
+- Terms of service & privacy policy ([#7](https://github.com/rojoma/toy-alchemy/issues/7))
+- Subjects beyond 6th-grade math (expansion mechanism: [#9](https://github.com/rojoma/toy-alchemy/issues/9))
+- LINE Bot front-end — development **paused**; code kept but not deployed
+
+---
+
+## Tech stack
+
+Python 3.11 · FastAPI · Jinja2 · OpenAI GPT-4o · vanilla JS · Web Speech API · Railway
+
+---
+
+## License
+
+Not yet set.
+
+---
+
+## Acknowledgements
+
+- MIT MAS.664 AI Studio (Spring 2026) teaching staff
+- Vygotsky's Zone of Proximal Development, Bloom's Taxonomy, Self-Determination Theory, Hattie's Visible Learning, Kapur's Productive Failure — the theoretical backbone of the Principal rubric
+
+Built for MAS.664 AI Studio at MIT Sloan, Spring 2026. Questions or feedback? Open an [issue on GitHub](https://github.com/rojoma/toy-alchemy/issues/new/choose).

--- a/training_field/web/app.py
+++ b/training_field/web/app.py
@@ -683,6 +683,44 @@ async def live_set_lang(session_id: str, body: dict):
     return {"ok": True, "lang": session.lang}
 
 
+FEEDBACK_DIR = Path(__file__).parent.parent / "reports" / "feedback"
+
+
+@app.post("/api/live/{session_id}/feedback")
+async def live_feedback(session_id: str, body: dict):
+    """Record a student's per-turn feedback on a teacher message.
+    body: {turn: int, rating: "up"|"down"|"confused", message?: str}
+    Appends to reports/feedback/{session_id}.json.
+    """
+    session = LIVE_SESSIONS.get(session_id)
+    # Don't require the session to be live — allow feedback on already-saved sessions too.
+    rating = body.get("rating")
+    if rating not in ("up", "down", "confused"):
+        raise HTTPException(400, "rating must be 'up', 'down', or 'confused'")
+    turn = body.get("turn")
+    if not isinstance(turn, int):
+        raise HTTPException(400, "turn (int) is required")
+
+    FEEDBACK_DIR.mkdir(parents=True, exist_ok=True)
+    path = FEEDBACK_DIR / f"{session_id}.json"
+    log = {"session_id": session_id, "entries": []}
+    if path.exists():
+        try:
+            log = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            pass
+    log["entries"].append({
+        "turn": turn,
+        "rating": rating,
+        "message": (body.get("message") or "")[:500],
+        "teacher_id": session.teacher.config.teacher_id if session else None,
+        "topic": session.topic if session else None,
+        "timestamp": datetime.datetime.now().isoformat(),
+    })
+    path.write_text(json.dumps(log, ensure_ascii=False, indent=2), encoding="utf-8")
+    return {"ok": True, "count": len(log["entries"])}
+
+
 @app.get("/api/live/{session_id}")
 async def live_status(session_id: str):
     """Get current state of a live session."""
@@ -883,6 +921,21 @@ async def session_page(request: Request, student_id: str, grade: str = "小6", s
 @app.get("/api/teachers")
 async def api_teachers():
     return {"teachers": list_teachers()}
+
+
+@app.get("/api/teacher/{teacher_id}/memory")
+async def api_teacher_memory(teacher_id: str):
+    """Return a teacher's accumulated Session Memory (what they've learned from past sessions)."""
+    from training_field.teacher_memory import MEMORY_DIR, load_memory_prompt
+    path = MEMORY_DIR / f"{teacher_id}.json"
+    if not path.exists():
+        return {"teacher_id": teacher_id, "sessions": [], "prompt": ""}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {"teacher_id": teacher_id, "sessions": [], "prompt": ""}
+    data["prompt"] = load_memory_prompt(teacher_id)
+    return data
 
 @app.get("/api/history")
 async def api_history(limit: int = 100, student_id: str | None = None):

--- a/training_field/web/templates/dashboard.html
+++ b/training_field/web/templates/dashboard.html
@@ -187,6 +187,41 @@ main{max-width:1280px;margin:0 auto;padding:96px 40px 140px}
   font-feature-settings:"tnum";font-weight:500;
 }
 
+/* ── Teacher cards (memory viz) ─────────────────── */
+.teacher-card{
+  display:flex;flex-direction:column;gap:14px;
+  background:var(--surface);border:1px solid var(--border);
+  border-radius:var(--radius-lg);padding:24px;
+  box-shadow:var(--shadow-sm);
+}
+.tc-head{display:flex;align-items:center;gap:14px}
+.tc-avatar{
+  width:40px;height:40px;border-radius:50%;
+  background:var(--surface-2);border:1px solid var(--border);
+  display:flex;align-items:center;justify-content:center;
+  font-size:13px;font-weight:600;
+}
+.tc-name{font-size:15px;font-weight:600;letter-spacing:-0.015em}
+.tc-origin{font-size:11px;color:var(--muted)}
+.tc-params{display:flex;gap:14px;font-size:11px;color:var(--muted)}
+.tc-params strong{color:var(--text);font-weight:600;font-feature-settings:"tnum"}
+.tc-memory-title{
+  font-size:10px;font-weight:600;letter-spacing:0.06em;
+  color:var(--muted);text-transform:uppercase;
+  padding-top:12px;border-top:1px solid var(--border);
+}
+.tc-memory-empty{font-size:12px;color:var(--muted);font-style:italic}
+.tc-memory-list{display:flex;flex-direction:column;gap:6px}
+.tc-memory-item{
+  font-size:12px;line-height:1.4;color:var(--text-secondary);
+  padding:8px 12px;background:var(--surface-2);border-radius:8px;
+  display:flex;gap:8px;align-items:flex-start;
+}
+.tc-memory-item-count{
+  flex-shrink:0;font-size:10px;font-weight:600;color:var(--muted);
+  padding:2px 6px;background:var(--surface);border-radius:10px;white-space:nowrap;
+}
+
 .sc-foot{
   display:flex;align-items:center;justify-content:space-between;
   padding-top:18px;border-top:1px solid var(--border);
@@ -344,6 +379,15 @@ tbody tr:hover{background:var(--surface-2)}
 
   <section class="section">
     <div class="section-head">
+      <div class="section-title">
+        <span data-i18n="teachers_label">Teacher Agents</span>
+      </div>
+    </div>
+    <div class="cards-grid" id="teacherGrid"></div>
+  </section>
+
+  <section class="section">
+    <div class="section-head">
       <div class="section-title" data-i18n="recent_sessions">Recent Sessions</div>
       <a href="/history" class="pill-select" style="text-decoration:none;background-image:none;padding:8px 18px" data-i18n="view_all">View all →</a>
     </div>
@@ -387,7 +431,9 @@ const AVAILABLE_GRADES = new Set(["小6"]);
 const AVAILABLE_SUBJECTS = new Set(["算数"]);
 const I18N = {
   ja: {
-    students_label:"生徒エージェント", recent_sessions:"最近のセッション",
+    students_label:"生徒エージェント", teachers_label:"先生エージェント", recent_sessions:"最近のセッション",
+    tc_recent_lessons:"最近の学び", tc_no_memory:"まだ学習記録はありません",
+    tc_patience:"忍耐", tc_warmth:"温かさ", tc_sessions:"セッション",
     total_sessions:"総セッション数", avg_gain:"平均ゲイン", pass_rate:"合格率",
     th_session:"セッション", th_student:"生徒", th_topic:"単元", th_depth:"深さ",
     th_pre:"事前", th_post:"事後", th_gain:"ゲイン", th_grade:"評価", th_delta:"Δ習熟",
@@ -402,7 +448,9 @@ const I18N = {
     topic_分数:"分数", topic_比:"比", topic_速さ:"速さ", topic_比例:"比例", topic_円:"円", topic_場合:"場合の数",
   },
   en: {
-    students_label:"Student Agents", recent_sessions:"Recent Sessions",
+    students_label:"Student Agents", teachers_label:"Teacher Agents", recent_sessions:"Recent Sessions",
+    tc_recent_lessons:"Recent lessons learned", tc_no_memory:"No session memory yet",
+    tc_patience:"Patience", tc_warmth:"Warmth", tc_sessions:"sessions",
     total_sessions:"total sessions", avg_gain:"avg gain", pass_rate:"pass rate",
     th_session:"Session", th_student:"Student", th_topic:"Topic", th_depth:"Depth",
     th_pre:"Pre", th_post:"Post", th_gain:"Gain", th_grade:"Grade", th_delta:"Δ Prof",
@@ -477,8 +525,82 @@ function applyLang(l){
   curLang=l; localStorage.setItem("tfLang",l);
   document.documentElement.lang = l;
 }
-function toggleLang(){ applyLang(curLang==="ja"?"en":"ja"); }
+function toggleLang(){ applyLang(curLang==="ja"?"en":"ja"); renderTeacherCards(); }
 applyLang(curLang);
+
+// ── Teacher Agents with Memory (Issue #14) ──────────
+const PARAM_KEY_EN = { warmth:"Warmth", patience_threshold:"Patience" };
+async function renderTeacherCards(){
+  const grid = document.getElementById("teacherGrid");
+  if(!grid) return;
+  let teachers = [];
+  try {
+    const r = await fetch("/api/teachers");
+    const d = await r.json();
+    teachers = d.teachers || [];
+  } catch(e){ return; }
+
+  // Fetch memory for each teacher in parallel
+  const memoryByTeacher = {};
+  await Promise.all(teachers.map(async (t)=>{
+    try {
+      const r = await fetch("/api/teacher/"+encodeURIComponent(t.teacher_id)+"/memory");
+      const d = await r.json();
+      memoryByTeacher[t.teacher_id] = d;
+    } catch(e){ memoryByTeacher[t.teacher_id] = {sessions:[]}; }
+  }));
+
+  const ja = curLang === "ja";
+  const T = (k)=> (I18N[curLang] && I18N[curLang][k]) || I18N.en[k] || k;
+  grid.innerHTML = "";
+  teachers.forEach(t => {
+    const mem = memoryByTeacher[t.teacher_id] || {sessions:[]};
+    const sessions = mem.sessions || [];
+    const n = sessions.length;
+    // Aggregate directives across sessions
+    const counts = {};
+    sessions.forEach(s => (s.directives||[]).forEach(d => { counts[d] = (counts[d]||0) + 1; }));
+    const top = Object.entries(counts).sort((a,b)=>b[1]-a[1]).slice(0,3);
+
+    const card = document.createElement("div");
+    card.className = "teacher-card";
+    const initials = (t.name||"--").replace(/[^A-Za-z]/g,"").slice(0,2).toUpperCase() || "--";
+    const originLabel = t.origin === "internal" ? (ja?"内製":"Internal") : (ja?"外部":"External");
+    const warmth = typeof t.warmth === "number" ? t.warmth.toFixed(1) : "—";
+    const patience = t.patience_threshold ?? "—";
+
+    let html = '<div class="tc-head">';
+    html += '<div class="tc-avatar">'+initials+'</div>';
+    html += '<div style="flex:1"><div class="tc-name">'+escapeHtml(t.name||"")+'</div>';
+    html += '<div class="tc-origin">'+originLabel+'</div></div></div>';
+    html += '<div class="tc-params">';
+    html += '<span>'+T("tc_warmth")+' <strong>'+warmth+'</strong></span>';
+    html += '<span>'+T("tc_patience")+' <strong>'+patience+'</strong></span>';
+    html += '<span><strong>'+n+'</strong> '+T("tc_sessions")+'</span>';
+    html += '</div>';
+    html += '<div class="tc-memory-title">'+T("tc_recent_lessons")+'</div>';
+    if(top.length === 0){
+      html += '<div class="tc-memory-empty">'+T("tc_no_memory")+'</div>';
+    } else {
+      html += '<div class="tc-memory-list">';
+      top.forEach(([directive, count]) => {
+        html += '<div class="tc-memory-item">';
+        html += '<span class="tc-memory-item-count">'+count+'/'+n+'</span>';
+        html += '<span>'+escapeHtml(directive)+'</span>';
+        html += '</div>';
+      });
+      html += '</div>';
+    }
+    card.innerHTML = html;
+    grid.appendChild(card);
+  });
+}
+
+function escapeHtml(s){
+  return (s||"").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
+}
+
+renderTeacherCards();
 </script>
 </body>
 </html>

--- a/training_field/web/templates/learn_session.html
+++ b/training_field/web/templates/learn_session.html
@@ -107,6 +107,26 @@ body{
 :root[data-theme="dark"] .question-box{
   background:var(--surface-2);border-color:var(--link);
 }
+
+/* Feedback buttons (per teacher bubble) */
+.fb-row{
+  display:flex;gap:6px;margin-top:6px;padding-left:6px;opacity:0;
+  transition:opacity .2s var(--ease);
+}
+.bubble-wrap.teacher:hover .fb-row,.fb-row.active{opacity:1}
+.fb-btn{
+  width:26px;height:26px;border-radius:50%;
+  display:inline-flex;align-items:center;justify-content:center;
+  background:var(--surface);border:1px solid var(--border-strong);
+  font-size:12px;cursor:pointer;padding:0;font-family:inherit;
+  transition:all .15s var(--ease);line-height:1;
+}
+.fb-btn:hover{background:var(--surface-2);transform:scale(1.1)}
+.fb-btn.selected.up{background:rgba(31,138,76,0.15);border-color:var(--success);color:var(--success)}
+.fb-btn.selected.down{background:rgba(193,39,45,0.12);border-color:var(--danger);color:var(--danger)}
+.fb-btn.selected.confused{background:rgba(178,80,0,0.12);border-color:var(--amber,#b25000);color:var(--amber,#b25000)}
+.fb-btn:disabled{cursor:not-allowed;opacity:0.5}
+
 .bubble.student{
   background:var(--student-bg);color:var(--student-fg);
   border-radius:var(--radius-lg) var(--radius-lg) 6px var(--radius-lg);
@@ -349,6 +369,9 @@ const I18N = {
     qa_send_explain:"もう一度説明してもらえますか？",
     qa_send_hint:"ヒントをください",
     qa_send_next:"次の問題に進んでください",
+    fb_up_title:"わかりやすかった",
+    fb_confused_title:"よくわからない",
+    fb_down_title:"わかりにくい",
   },
   en: {
     back:"← Back",
@@ -383,6 +406,9 @@ const I18N = {
     qa_send_explain:"Can you explain that again?",
     qa_send_hint:"Give me a hint please.",
     qa_send_next:"Let's move to the next problem.",
+    fb_up_title:"Clear and helpful",
+    fb_confused_title:"Not sure I follow",
+    fb_down_title:"Not helpful",
   }
 };
 let curLang = localStorage.getItem("tfLang") || "en";
@@ -489,6 +515,46 @@ async function showTeacherMsg(text, opts){
     bubble.appendChild(qBox);
     await typeInto(qBox, question, 70);
   }
+  // Feedback buttons — only for non-test teaching messages
+  if(!opts.testKind){
+    appendFeedbackRow(wrap);
+  }
+}
+
+// ── Feedback row (Issue #13) ─────────────────────
+let teacherTurnCounter = 0;
+function appendFeedbackRow(bubbleWrap){
+  teacherTurnCounter += 1;
+  const turnId = teacherTurnCounter;
+  const row = document.createElement("div");
+  row.className = "fb-row";
+  row.innerHTML =
+    '<button class="fb-btn" data-rating="up" title="'+t("fb_up_title")+'">👍</button>'+
+    '<button class="fb-btn" data-rating="confused" title="'+t("fb_confused_title")+'">❓</button>'+
+    '<button class="fb-btn" data-rating="down" title="'+t("fb_down_title")+'">👎</button>';
+  row.querySelectorAll(".fb-btn").forEach(btn => {
+    btn.addEventListener("click", () => submitFeedback(row, btn, turnId));
+  });
+  bubbleWrap.appendChild(row);
+}
+
+async function submitFeedback(row, btn, turn){
+  if(!sessionId) return;
+  const rating = btn.dataset.rating;
+  // Disable other buttons, mark selected
+  row.querySelectorAll(".fb-btn").forEach(b => {
+    b.disabled = true;
+    b.classList.remove("selected", "up", "down", "confused");
+  });
+  btn.classList.add("selected", rating);
+  row.classList.add("active");
+  try {
+    await fetch("/api/live/"+sessionId+"/feedback", {
+      method:"POST",
+      headers:{"Content-Type":"application/json"},
+      body: JSON.stringify({turn, rating}),
+    });
+  } catch(e){ /* silent — UI already reflects choice */ }
 }
 
 function showTestBanner(kind){


### PR DESCRIPTION
## 概要 / Summary
フィードバックループを閉じる2機能と、READMEの全面リライト。
- **#13** 各Teacher発言にGood/Bad/? ボタン → サーバーに保存
- **#14** Dashboard で Teacher Memory を可視化
- **docs** README を開発者向け単独構成から、保護者/教育者/研究者/エンジニア向けの多層構成に書き直し（Trust Layer方式）

## なぜ / Why
- #13: 先生の発言がおかしい時、生徒は「会話を続ける」か「End Session」しかなかった。気軽にシグナルを送れるようにする。
- #14: Teacher Memory は仕組みとしては動いているが、誰も中身を見られない（JSONを直接開くしかなかった）。
- docs: 現READMEは共同開発者向け一辺倒で、GitHub経由で来た一般訪問者（保護者・教育者・MIT評価者）に対して「何のプロジェクトか・なぜ作ったか」が伝わらなかった。

## 変更内容 / Changes

### #13 フィードバックボタン
- 各 Teacher バブル（非テスト時のみ）に 👍 ❓ 👎 ボタン
- hover でフェードイン、選択後は色付きで残る
- クリックで \`POST /api/live/{session_id}/feedback\` を呼び、\`reports/feedback/{session_id}.json\` に追記
- ログ形式:
  \`\`\`json
  {
    "session_id": "live_...",
    "entries": [
      {"turn": 1, "rating": "up", "teacher_id": "t001", "topic": "...", "timestamp": "..."}
    ]
  }
  \`\`\`
- i18n 対応（JA/EN ツールチップ）

### #14 Teacher Memory 可視化
- **新API**: \`GET /api/teacher/{teacher_id}/memory\`
  戻り値: memory JSON 全文 + \`prompt\` (プロンプト注入文字列)
- **Dashboard新セクション**: 「Teacher Agents」カードグリッド
  - アバター / 名前 / internal or external
  - Warmth / Patience / 記録セッション数
  - Top 3 の Referee directive を N/total バッジ付きで表示
  - 記録無しの場合は「まだ学習記録はありません」
- JA/EN 切替で再描画

### docs: README rewrite
- Trust Layer (MAS.664 Team 8) 方式の構造を採用: Problem → What it does → 技術的コア2本（TeacherConfig / Principal rubric）→ Live → Quick start → Architecture → Scope & limitations
- 英語に統一、トーンは保護者/教育者向け
- TeacherConfig のパラメータ一覧とPrincipal の6要素ルーブリックを明示的に掲載（このプロジェクトの核）
- Scope & limitations から issues #28-#33, #7, #9 へ相互リンク（ロードマップ提示）
- LINE Bot セクションを "paused" と明記（開発停止中）
- 既存のエンジニア向けセットアップ・開発フローは温存

## 動作確認 / Testing
- [x] \`GET /api/teacher/t001/memory\` → 200 OK、空メモリでも正しく返る
- [x] \`POST /api/live/{id}/feedback\` → 200 OK、ファイルに追記
- [x] Dashboard の teacherGrid が描画される
- [x] JS/Python 構文チェック
- [ ] 実セッションでフィードバックを送信 → ファイルが増える
- [ ] Dashboard に Teacher カードが表示されて直感的である
- [x] README の Markdown レンダリング確認（GitHub上）

## レビュアーへの注意 / Notes for Reviewer
- \`feedback/\` ディレクトリは \`.gitignore\` 対象外（現状では未記載）。運用で溜まっていくなら Railway Volume mount + gitignore 追加が必要。
- マスターデータとしての Teacher Agents（Warmth/Patience）は既に API にあるが、Memory と組み合わせて見える化するのが本PRの狙い。
- READMEは Team 8 の Trust Layer (https://github.com/jamesww23/trust-layer) の構造を踏襲。学術提出/一般公開の両方を想定。

## 関連
Closes #13
Closes #14