### PR TITLE
[Fix] Wire evaluator.session_grade through API and CLI (fixes #21)

### DIFF
--- a/training_field/SKILL.md
+++ b/training_field/SKILL.md
@@ -238,13 +238,14 @@ enabled. Don't poll, don't retry early — wait for the response.
   "avg_bloom": 2.4,
   "hallucination_rate": 0.0,
   "direct_answer_rate": 0.0,
-  "session_grade": {"grade": "○", "status": "pass", "score": 80},
+  "session_grade": {"grade": "○", "status": "pass", "basis": "post_test"},
   "skills_proposal_path": null
 }
 ```
 
 `learning_gain` is the headline metric: post − pre. Higher is better.
-`session_grade.status` is one of `excellent` / `pass` / `fail`.
+`session_grade.status` is one of `excellent` / `pass` / `marginal` / `fail`.
+`session_grade.basis` indicates what the grade was computed from: `"post_test"` (when a post-test score is available) or `"proficiency_delta"` (test-less sessions, graded from pre→post proficiency change).
 
 ---
 

--- a/training_field/referee_agent.py
+++ b/training_field/referee_agent.py
@@ -144,6 +144,8 @@ Evaluate this exchange."""
         }
 
     def grade_session(self, post_test_score: float) -> dict:
+        # DEPRECATED: use Evaluator.evaluate(...).session_grade instead.
+        # Only considers post_test_score; returns "×"/fail for test-less sessions.
         if post_test_score >= 90:
             return {"grade": "◎", "status": "excellent", "score": post_test_score}
         elif post_test_score >= 70:

--- a/training_field/session_runner.py
+++ b/training_field/session_runner.py
@@ -125,8 +125,8 @@ async def run_training_session(config: SessionConfig) -> dict:
         console.print(f'  Post-test: {post_test_score}/100')
     final_proficiency = student.proficiency_model.topic_proficiencies.get(config.topic, 0)
     update_check = principal.check_skills_update_trigger()
-    grade_result = principal.grade_session(post_test_score or 0)
     evaluation = evaluator.evaluate(session_id=session_id, turn_evaluations=turn_evaluations, pre_score=pre_test_score, post_score=post_test_score, student_id=config.student_id, teacher_id=config.teacher_id, topic=config.topic, grade=config.grade, subject=config.subject, depth=config.depth, initial_proficiency=initial_proficiency, final_proficiency=final_proficiency, cost_tracker=cost_tracker, principal_update_check=update_check)
+    grade_result = evaluation.session_grade
     report_path = evaluator.generate_report(evaluation)
     record = ExperimentRecord(exp_id=session_id, hypothesis_id=config.hypothesis_id, timestamp=evaluation.timestamp, student_id=config.student_id, teacher_id=config.teacher_id, topic=config.topic, grade=config.grade, subject=config.subject, depth=config.depth, teaching_style=config.teaching_style, skills_used=teacher.config.selected_skills, pre_test_score=pre_test_score, post_test_score=post_test_score, learning_gain=evaluation.learning_gain, proficiency_delta=evaluation.proficiency_delta, hallucination_rate=evaluation.hallucination_rate, direct_answer_rate=evaluation.direct_answer_rate, avg_zpd_alignment=evaluation.avg_zpd_alignment, avg_bloom_level=evaluation.avg_bloom_level, frustration_events=evaluation.frustration_events, aha_moments=evaluation.aha_moments, teacher_compatibility_score=evaluation.teacher_compatibility_score, total_tokens=evaluation.total_tokens_used, cost_usd=evaluation.estimated_cost_usd, session_grade=grade_result['grade'])
     registry.register(record)

--- a/training_field/web/app.py
+++ b/training_field/web/app.py
@@ -1121,8 +1121,8 @@ async def run_session(body: dict):
                "topic": config.topic, "selected_skills": teacher.config.selected_skills}
         proposal = principal.generate_skills_proposal(update_check, ctx)
         proposal_path = str(principal.write_proposal(proposal, update_check, ctx))
-    grade_result = principal.grade_session(post_test_score or 0)
     evaluation = evaluator.evaluate(session_id=session_id, turn_evaluations=turn_evaluations, pre_score=pre_test_score, post_score=post_test_score, student_id=config.student_id, teacher_id=teacher.config.teacher_id, topic=config.topic, grade=config.grade, subject=config.subject, depth=config.depth, initial_proficiency=initial_prof, final_proficiency=final_prof, cost_tracker=cost_tracker, principal_update_check=update_check)
+    grade_result = evaluation.session_grade
     evaluator.generate_report(evaluation)
     record = ExperimentRecord(exp_id=session_id, hypothesis_id=None, timestamp=datetime.datetime.now().isoformat(), student_id=config.student_id, teacher_id=teacher.config.teacher_id, topic=config.topic, grade=config.grade, subject=config.subject, depth=config.depth, teaching_style="SOCRATIC", skills_used=teacher.config.selected_skills, pre_test_score=pre_test_score, post_test_score=post_test_score, learning_gain=evaluation.learning_gain, proficiency_delta=evaluation.proficiency_delta, hallucination_rate=evaluation.hallucination_rate, direct_answer_rate=evaluation.direct_answer_rate, avg_zpd_alignment=evaluation.avg_zpd_alignment, avg_bloom_level=evaluation.avg_bloom_level, frustration_events=evaluation.frustration_events, aha_moments=evaluation.aha_moments, teacher_compatibility_score=evaluation.teacher_compatibility_score, total_tokens=evaluation.total_tokens_used, cost_usd=evaluation.estimated_cost_usd, session_grade=grade_result["grade"])
     registry.register(record)
@@ -1270,7 +1270,6 @@ async def run_session_stream(
             post_test_score = round(correct/len(qs)*100)
             yield f"data: {json.dumps({'type':'test_score','which':'post','score':post_test_score})}\n\n"
         final_prof = student.proficiency_model.topic_proficiencies.get(topic, 0)
-        grade_result = principal.grade_session(post_test_score or 0) if post_test else None
         # Skills semi-auto: generate proposal if trigger fires
         update_check = principal.check_skills_update_trigger()
         proposal_path = None
@@ -1283,6 +1282,7 @@ async def run_session_stream(
             await asyncio.sleep(0)
 
         # ── Persist session (mirror batch path) ────────────────────
+        grade_result = None
         try:
             evaluation = evaluator.evaluate(
                 session_id=session_id, turn_evaluations=turn_evaluations,
@@ -1293,6 +1293,7 @@ async def run_session_stream(
                 final_proficiency=final_prof, cost_tracker=cost_tracker,
                 principal_update_check=update_check,
             )
+            grade_result = evaluation.session_grade
             evaluator.generate_report(evaluation)
             record = ExperimentRecord(
                 exp_id=session_id, hypothesis_id=None,


### PR DESCRIPTION
## 問題 / Problem
PR #22 でテストなしセッション向けに \`Evaluator.evaluate\` の中で proficiency delta ベースの grading を入れたが、**配線が古いまま**だった。\`app.py\` と \`session_runner.py\` の3箇所で \`principal.grade_session(post_test_score or 0)\` を呼び続けており、\`post_test_score=None\` のとき score=0 として渡されて常に \`{grade: "×", status: "fail", score: 0}\` を返していた。

Openclaw（External Agent）の観測でもこの症状が再現していた:
- Initial proficiency: 31.7 → Final: 35.9 (+4.2ポイント)
- しかし \`session_grade\` は \`{"grade": "×", "status": "fail", "score": 0}\` のまま（"score" キーの存在が、Evaluator 経由ではなく \`principal.grade_session\` 経由であることの証拠）

## 原因 / Root Cause
\`evaluator.evaluate()\` が返す \`EvaluationResult.session_grade\` は正しく計算されていたが、**API/CLI 層が見ていなかった**。\`principal.grade_session()\` の古い戻り値が transcript・ExperimentRecord・JSONResponse・SSE done イベントすべてに流れていた。

## 修正 / Changes
3箇所全てを \`evaluation.session_grade\` に置き換え:
- \`training_field/web/app.py:1124\` （\`/api/run-session\`）
- \`training_field/web/app.py:1273\` （\`/api/run-session-stream\`）
- \`training_field/session_runner.py:128\` （CLI batch runner）

順序変更: 以前は \`principal.grade_session()\` を呼んでから \`evaluator.evaluate()\` を呼んでいたが、今は evaluator を先に呼んでその \`session_grade\` を使う。

### 付随変更
- \`PrincipalAgent.grade_session\` を deprecated 扱いに（コメントのみ）。外部スクリプトから呼ばれている可能性を考慮して実体は残す。
- \`training_field/SKILL.md\` のレスポンス例とフィールド説明を更新:
  - \`session_grade\` の payload から \`score\` が消え、\`basis\` (\`"post_test"\` または \`"proficiency_delta"\`) が入るように
  - \`status\` の候補に \`"marginal"\` を追加（△ レーティング用）

## 効果 / Behavior After
- **テストなし**で proficiency +5以上 → \`{grade: "◎", status: "excellent", basis: "proficiency_delta"}\`
- **テストなし**で proficiency +2〜+5 → \`{grade: "○", status: "pass", basis: "proficiency_delta"}\`
- **テストなし**で proficiency 0〜+2 → \`{grade: "△", status: "marginal", basis: "proficiency_delta"}\`
- **テストなし**で proficiency マイナス or 品質悪い → \`{grade: "×", status: "fail", basis: "proficiency_delta"}\`
- **テストあり** → 従来通り post-score ベース（basis: "post_test"）

## 検証 / Testing
- [x] 3ファイルの構文チェック (py_compile)
- [x] \`session_grade\` を参照している側 (\`session.html:866\`, \`evaluator.py:78\` テンプレート, SKILL.md ドキュメント) は \`grade\` / \`status\` キーのみ使用 → 後方互換OK
- [x] \`principal.grade_session\` 本体コードからの呼び出しは全除去
- [ ] ライブセッション実行確認（要デプロイ後）

## 関連 / Related
Closes #21
- PR #22 の追完成（#22 はロジックを直したが配線を直し忘れた）
- #35（合格点ベースの評価廃止・学習デルタベースに統一）の地ならしにもなる