### PR TITLE
[Fix] Remove unguarded qbank.init_db() at request entry (fixes #20)

### DIFF
--- a/training_field/web/app.py
+++ b/training_field/web/app.py
@@ -1069,7 +1069,9 @@ async def run_session(body: dict):
     registry = ExperimentRegistry()
     qbank = QuestionBank()
     cost_tracker = CostTracker()
-    await qbank.init_db()
+    # init_db is handled inside qbank.get_test_questions() with fallback;
+    # calling it unguarded here crashes the request with 500 when the DB path
+    # is not writable (e.g. Railway filesystem constraints). See #20.
 
     initial_prof = student.proficiency_model.topic_proficiencies.get(
         config.topic, student.proficiency_model.proficiency)
@@ -1184,7 +1186,8 @@ async def run_session_stream(
         registry = ExperimentRegistry()
         cost_tracker = CostTracker()
         qbank = QuestionBank()
-        await qbank.init_db()
+        # init_db is handled inside qbank.get_test_questions() with fallback;
+        # see note on the batch /api/run-session call site above (#20).
         initial_prof = student.proficiency_model.topic_proficiencies.get(
             config.topic, student.proficiency_model.proficiency)
         turn_evaluations = []


### PR DESCRIPTION
## 問題 / Problem
\`POST /api/run-session\` and \`GET /api/run-session-stream\` call \`await qbank.init_db()\` at the top of the request handler, unguarded. PR #23 added fallback handling inside \`QuestionBank.get_test_questions()\`, but that resilience only kicks in once we reach \`get_test_questions\` — any earlier failure in \`init_db\` (for example because the DB path isn't writable on Railway) bubbles up as a 500 before any pre/post-test code runs. This matches the 500 Openclaw observed with \`run_pre_test: true\`.

## Root cause
\`QuestionBank.get_test_questions()\` already calls \`init_db()\` internally and falls back to \`_generate_fallback_questions\` when DB init fails. The eager \`await qbank.init_db()\` at request entry is therefore **both redundant and the only unprotected call path** — an ideal trap.

## Fix
Remove the eager \`init_db()\` call from both endpoints and leave a pointer comment. No behavior change when the DB is healthy; when it's not, the request now proceeds instead of 500ing.

- \`training_field/web/app.py:1072\` (\`/api/run-session\`)
- \`training_field/web/app.py:1187\` (\`/api/run-session-stream\`)

## Testing
- [x] Syntax check (py_compile)
- [x] Logic review: no path relies on \`init_db\` having been called at request entry
- [ ] Live retest on Railway after deploy — Openclaw's 500 case with \`run_pre_test: true\` should return 200

## Related
Closes #20
- Completes the intent of PR #23 (#23 fixed the data path; this fixes the control flow guard at the entry)