### PR TITLE
[Fix] Replace Fail/× grading with learning-delta vocabulary (fixes #35)

### DIFF
--- a/training_field/SKILL.md
+++ b/training_field/SKILL.md
@@ -244,8 +244,20 @@ enabled. Don't poll, don't retry early — wait for the response.
 ```
 
 `learning_gain` is the headline metric: post − pre. Higher is better.
-`session_grade.status` is one of `excellent` / `pass` / `marginal` / `fail`.
-`session_grade.basis` indicates what the grade was computed from: `"post_test"` (when a post-test score is available) or `"proficiency_delta"` (test-less sessions, graded from pre→post proficiency change).
+
+`session_grade.status` is one of:
+| status | grade | meaning |
+|---|---|---|
+| `excellent` | ◎ | learning delta ≥ 5 with good quality signals |
+| `pass` | ○ | learning delta ≥ 2 with good quality signals |
+| `room_to_improve` | △ | learning delta ≥ 0 with good quality signals |
+| `review_needed` | ⚠ | learning delta < 0, or hallucination / direct-answer flags triggered |
+
+Grading is learning-delta based in all cases — there is no absolute-cutoff "fail". A student who jumped from 30→60 is treated as an excellent session even if the absolute post-score is below a traditional "passing" line. See #35 for rationale.
+
+`session_grade.basis` indicates what the delta was computed from: `"post_test"` (uses `post_score - pre_score` when a post-test score is available) or `"proficiency_delta"` (test-less sessions, graded from pre→post proficiency change).
+
+**Legacy grades:** session records written before #35 may contain the old `×` grade with status `"fail"`. The API accepts both; new sessions only emit the new vocabulary.
 
 ---
 

--- a/training_field/evaluator.py
+++ b/training_field/evaluator.py
@@ -147,27 +147,40 @@ class Evaluator:
         cost = cost_tracker.total_cost_usd()
         cpg = (cost / learning_gain) if learning_gain > 0 else None
 
-        # Grade session based on post_test_score if available, otherwise use proficiency delta
+        # Grade session on learning delta + quality signals.
+        # No "fail" / "×" — a session that didn't help the student is framed as
+        # "review_needed" so the student doesn't see a failing mark and the
+        # teacher/parent knows to look at the transcript.
+        #
+        # Quality signals override: hallucination or answer-given-directly
+        # always forces review_needed regardless of score/delta.
+        quality_ok = (
+            halluc_rate < 0.1
+            and direct_rate < 0.1
+            and avg_zpd >= 0.6
+        )
+
         if post_score is not None:
-            # Test-based grading
-            if post_score >= 90:
-                session_grade = {"grade": "◎", "status": "excellent", "basis": "post_test"}
-            elif post_score >= 70:
-                session_grade = {"grade": "○", "status": "pass", "basis": "post_test"}
-            else:
-                session_grade = {"grade": "×", "status": "fail", "basis": "post_test"}
+            # Test-based: prefer learning gain (post - pre) over absolute post.
+            # Absolute "cutoff" scoring was removed because a low-proficiency
+            # student who jumps from 30 → 60 was being scored the same as a
+            # stagnating one — see #35.
+            delta_for_grade = learning_gain
+            basis = "post_test"
         else:
-            # Proficiency-based grading when no tests are run
-            # Also consider quality metrics (hallucination, direct answers, ZPD)
-            quality_ok = halluc_rate < 0.1 and direct_rate < 0.1 and avg_zpd >= 0.6
-            if proficiency_delta >= 5 and quality_ok:
-                session_grade = {"grade": "◎", "status": "excellent", "basis": "proficiency_delta"}
-            elif proficiency_delta >= 2 and quality_ok:
-                session_grade = {"grade": "○", "status": "pass", "basis": "proficiency_delta"}
-            elif proficiency_delta >= 0 and quality_ok:
-                session_grade = {"grade": "△", "status": "marginal", "basis": "proficiency_delta"}
-            else:
-                session_grade = {"grade": "×", "status": "fail", "basis": "proficiency_delta"}
+            delta_for_grade = proficiency_delta
+            basis = "proficiency_delta"
+
+        if not quality_ok:
+            session_grade = {"grade": "⚠", "status": "review_needed", "basis": basis}
+        elif delta_for_grade >= 5:
+            session_grade = {"grade": "◎", "status": "excellent", "basis": basis}
+        elif delta_for_grade >= 2:
+            session_grade = {"grade": "○", "status": "pass", "basis": basis}
+        elif delta_for_grade >= 0:
+            session_grade = {"grade": "△", "status": "room_to_improve", "basis": basis}
+        else:
+            session_grade = {"grade": "⚠", "status": "review_needed", "basis": basis}
 
         return EvaluationResult(
             session_id=session_id,

--- a/training_field/experiment_registry.py
+++ b/training_field/experiment_registry.py
@@ -131,6 +131,6 @@ class ExperimentRegistry:
             "avg_learning_gain": round(sum(gains) / len(gains), 2) if gains else 0,
             "total_cost_usd": round(sum(e.get("cost_usd", 0) for e in experiments), 4),
             "pass_rate": round(
-                sum(1 for e in experiments if e.get("session_grade") in ["◎", "○"]) / len(experiments), 3
+                sum(1 for e in experiments if e.get("session_grade") in ["◎", "○", "△"]) / len(experiments), 3
             ),
         }

--- a/training_field/referee_agent.py
+++ b/training_field/referee_agent.py
@@ -145,7 +145,9 @@ Evaluate this exchange."""
 
     def grade_session(self, post_test_score: float) -> dict:
         # DEPRECATED: use Evaluator.evaluate(...).session_grade instead.
-        # Only considers post_test_score; returns "×"/fail for test-less sessions.
+        # This function uses the old absolute-cutoff vocabulary ("×"/fail) and
+        # doesn't apply the learning-delta framing from #35. Kept only for
+        # backward compatibility with any external callers.
         if post_test_score >= 90:
             return {"grade": "◎", "status": "excellent", "score": post_test_score}
         elif post_test_score >= 70:

--- a/training_field/web/app.py
+++ b/training_field/web/app.py
@@ -1017,7 +1017,7 @@ async def agent_leaderboard(_auth: bool = Depends(require_field_key), limit: int
         slot["sessions"] += 1
         if r.get("learning_gain") is not None:
             slot["gains"].append(r["learning_gain"])
-        if r.get("session_grade") in ("◎", "○"):
+        if r.get("session_grade") in ("◎", "○", "△"):
             slot["passes"] += 1
         slot["total_zpd"] += r.get("avg_zpd_alignment") or 0
     out = []

--- a/training_field/web/templates/history.html
+++ b/training_field/web/templates/history.html
@@ -102,6 +102,7 @@ main{max-width:1280px;margin:0 auto;padding:64px 40px 120px}
 }
 .card.grade-ex::before{background:var(--success)}
 .card.grade-pass::before{background:var(--link)}
+.card.grade-marginal::before{background:var(--warning, #f59e0b)}
 .card.grade-fail::before{background:var(--danger)}
 .card:hover{
   transform:translateY(-2px);
@@ -121,9 +122,11 @@ main{max-width:1280px;margin:0 auto;padding:64px 40px 120px}
 }
 .g-ex{background:rgba(31,138,76,0.14);color:var(--success)}
 .g-pass{background:rgba(0,113,227,0.14);color:var(--link)}
+.g-marginal{background:rgba(245,158,11,0.14);color:var(--warning, #f59e0b)}
 .g-fail{background:rgba(193,39,45,0.12);color:var(--danger)}
 :root[data-theme="dark"] .g-ex{background:rgba(48,209,88,0.18)}
 :root[data-theme="dark"] .g-pass{background:rgba(41,151,255,0.18)}
+:root[data-theme="dark"] .g-marginal{background:rgba(250,179,37,0.2)}
 :root[data-theme="dark"] .g-fail{background:rgba(255,69,58,0.18)}
 
 .card-meta{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
@@ -246,14 +249,14 @@ main{max-width:1280px;margin:0 auto;padding:64px 40px 120px}
     <button class="filter-chip" data-filter="live">Live</button>
     <button class="filter-chip" data-filter="observatory">Observatory</button>
     <button class="filter-chip" data-filter="passed">◎ ○ Passed</button>
-    <button class="filter-chip" data-filter="failed">× Failed</button>
+    <button class="filter-chip" data-filter="failed">⚠ Review</button>
   </div>
 
   {% if sessions %}
   <div class="grid" id="grid">
     {% for r in sessions %}
     {% set is_live = r.exp_id.startswith('live_') %}
-    {% set grade_class = 'grade-ex' if r.session_grade == '◎' else ('grade-pass' if r.session_grade == '○' else 'grade-fail') %}
+    {% set grade_class = 'grade-ex' if r.session_grade == '◎' else ('grade-pass' if r.session_grade == '○' else ('grade-marginal' if r.session_grade == '△' else 'grade-fail')) %}
     {% set grade_passed = r.session_grade in ['◎', '○'] %}
     <div class="card {{ grade_class }}"
          data-mode="{{ 'live' if is_live else 'observatory' }}"
@@ -264,7 +267,9 @@ main{max-width:1280px;margin:0 auto;padding:64px 40px 120px}
         <div class="card-topic" data-i18n-tx>{{ r.topic or '—' }}</div>
         {% if r.session_grade == '◎' %}<span class="grade-mark g-ex">◎</span>
         {% elif r.session_grade == '○' %}<span class="grade-mark g-pass">○</span>
-        {% else %}<span class="grade-mark g-fail">×</span>{% endif %}
+        {% elif r.session_grade == '△' %}<span class="grade-mark g-marginal">△</span>
+        {% elif r.session_grade == '⚠' %}<span class="grade-mark g-fail">⚠</span>
+        {% else %}<span class="grade-mark g-fail">⚠</span>{% endif %}
       </div>
 
       <div class="card-meta">

--- a/training_field/web/templates/session.html
+++ b/training_field/web/templates/session.html
@@ -859,11 +859,12 @@ function startStream(opts){
           const g=d.session_grade,gd=document.getElementById("gd");gd.style.display="block";
           if(g.status=="excellent"){gd.style.background="rgba(31,138,76,0.10)";gd.style.color="var(--success)";gd.textContent="◎ Excellent";}
           else if(g.status=="pass"){gd.style.background="rgba(0,113,227,0.10)";gd.style.color="var(--link)";gd.textContent="○ Pass";}
-          else{gd.style.background="rgba(193,39,45,0.10)";gd.style.color="var(--danger)";gd.textContent="× Fail";}
+          else if(g.status=="room_to_improve"||g.status=="marginal"){gd.style.background="rgba(245,158,11,0.10)";gd.style.color="var(--warning, #f59e0b)";gd.textContent="△ Room to improve";}
+          else{gd.style.background="rgba(193,39,45,0.10)";gd.style.color="var(--danger)";gd.textContent="⚠ Review needed";}
         }
         document.getElementById("brun").disabled=false;
         if(d.session_grade){
-          ss("done", (d.session_grade.status=="pass"||d.session_grade.status=="excellent")?"status_pass":"status_fail");
+          ss("done", (d.session_grade.status=="pass"||d.session_grade.status=="excellent"||d.session_grade.status=="room_to_improve"||d.session_grade.status=="marginal")?"status_pass":"status_fail");
         } else {
           ss("done","status_done");
         }


### PR DESCRIPTION
## 概要 / Summary
\`×\` / \`fail\` の絶対基準評価を廃止し、学習デルタベースの評価に統一。「失敗」ではなく「要レビュー」に表記を変更。

## なぜ / Why
- 合格点の根拠が不明確（過去の議論は #21 / #35）
- Initial proficiency が低い生徒ほど不利 — 30→60 と停滞が同じ "× fail" になる
- "×" / "fail" の表示は生徒・保護者のモチベーションを削ぐ（#17 系フィードバック）
- PR #22/#36 で既に delta ベースに部分移行 → 方向性は確定

## 評価テーブル / Grading table
| 旧 | 新 | 条件 |
|---|---|---|
| ◎ excellent | ◎ excellent | delta ≥ 5 + quality ok |
| ○ pass | ○ pass | delta ≥ 2 + quality ok |
| △ marginal | △ **room_to_improve** | delta ≥ 0 + quality ok |
| × fail | ⚠ **review_needed** | delta < 0 OR quality flags |

**Quality flags**: hallucination_rate ≥ 10%, direct_answer_rate ≥ 10%, avg_zpd < 0.6 のいずれか。

**Delta**: テストありなら learning_gain (post − pre)、テストなしなら proficiency_delta (pre→post 習熟度変化)。

## 変更ファイル / Changes
- \`training_field/evaluator.py\` — 単一 grading path（delta + quality で分岐）
- \`training_field/web/templates/history.html\` — △/⚠ の描画追加、フィルタチップ文言変更
- \`training_field/web/templates/session.html\` — ライブセッション完了時の表示更新
- \`training_field/experiment_registry.py\`, \`web/app.py\` — pass_rate・per-teacher passes に △ を含める
- \`training_field/referee_agent.py\` — deprecated メソッドのコメント強化
- \`training_field/SKILL.md\` — status テーブル + legacy note

## 後方互換 / Backward compat
- 既存セッションの \`×\` レコード → \`⚠\` として表示（history.html の else 分岐でフォールスルー）
- \`referee_agent.grade_session()\` は旧語彙のまま残す（外部スクリプトの呼び出し用、deprecated 明記）
- 既存 JSON レコード（\`experiment_registry.json\`, \`reports/\` 配下）は変更なし

## 検証 / Testing
- [x] py_compile（全変更 Python ファイル）
- [x] Jinja テンプレート構文チェック（history.html, session.html）
- [x] 旧 "×" レコードが新 UI で \`⚠\` としてフォールバック表示されることを確認（else 分岐）
- [ ] Live app で新セッションが新ラベルで表示されるか確認（deploy 後）
- [ ] Live app の history ページで legacy × レコードが混在表示されるか確認

## 関連 / Related
Closes #35
- PR #36 の延長（デルタベース評価の完成形）
- #17（モチベーション系フィードバック）の構造的対処
- #34（Pre/Post必須化）と補完関係