### PR TITLE
[Feature] Pre/Post tests: mandatory in Observatory, opt-out in live sessions (fixes #34)

### DIFF
--- a/training_field/web/app.py
+++ b/training_field/web/app.py
@@ -275,6 +275,9 @@ class LiveSession:
     key_moments: list = _field(default_factory=list)  # [{turn, delta, summary}] — biggest learning moments
     is_complete: bool = False
     started_at: str = ""
+    # per-session flags (see #34): default True keeps existing behavior
+    run_pre_test: bool = True
+    run_post_test: bool = True
 
     @property
     def total_turns(self):
@@ -336,7 +339,13 @@ LIVE_SESSIONS: dict[str, LiveSession] = {}
 
 @app.post("/api/live/start")
 async def live_start(body: dict):
-    """Start a live (human-student) session. Begins with pre-test."""
+    """Start a live (human-student) session.
+
+    By default the session begins with a pre-test. Callers can skip either
+    test by passing `run_pre_test: false` or `run_post_test: false` in the
+    body — see #34 (test-less path is meant for light conversation modes
+    and for the homework-scope flow planned in #28).
+    """
     teacher_id = body.get("teacher_id", "t001")
     topic = body.get("topic", "分数のかけ算とわり算")
     depth = body.get("depth", "quick")
@@ -344,6 +353,8 @@ async def live_start(body: dict):
     subject = body.get("subject", "算数")
     lang = body.get("lang", "en")
     student_label = body.get("student_name", "You")
+    run_pre_test = bool(body.get("run_pre_test", True))
+    run_post_test = bool(body.get("run_post_test", True))
 
     gcode = GRADE_CODES.get(grade_str, 6)
     teacher = load_teacher(teacher_id)
@@ -353,6 +364,7 @@ async def live_start(body: dict):
     phases = PHASE_CONFIG["unlimited"]
     sid = f"live_{uuid.uuid4().hex[:8]}"
 
+    initial_phase = "pre_test" if run_pre_test else "teaching"
     session = LiveSession(
         session_id=sid,
         teacher=teacher,
@@ -362,33 +374,50 @@ async def live_start(body: dict):
         depth=depth, lang=lang,
         teacher_name=teacher.config.name,
         student_label=student_label,
-        session_phase="pre_test",
-        test_question_num=1,
+        session_phase=initial_phase,
+        test_question_num=1 if run_pre_test else 0,
         proficiency=50.0, initial_proficiency=50.0,
         started_at=datetime.datetime.now().isoformat(),
+        run_pre_test=run_pre_test,
+        run_post_test=run_post_test,
     )
     LIVE_SESSIONS[sid] = session
 
-    # Generate first pre-test question
-    prompt = _test_prompt(teacher.config, topic, gcode, subject, lang, 1, NUM_TEST_QUESTIONS, student_label, is_post=False)
-    from openai import OpenAI
-    client = OpenAI()
-    resp = client.chat.completions.create(
-        model="gpt-4o", max_tokens=300,
-        messages=[{"role": "system", "content": prompt},
-                  {"role": "user", "content": f"Ask question 1 of {NUM_TEST_QUESTIONS} about {display_topic(topic, lang)}."}],
+    if run_pre_test:
+        # Generate first pre-test question
+        prompt = _test_prompt(teacher.config, topic, gcode, subject, lang, 1, NUM_TEST_QUESTIONS, student_label, is_post=False)
+        from openai import OpenAI
+        client = OpenAI()
+        resp = client.chat.completions.create(
+            model="gpt-4o", max_tokens=300,
+            messages=[{"role": "system", "content": prompt},
+                      {"role": "user", "content": f"Ask question 1 of {NUM_TEST_QUESTIONS} about {display_topic(topic, lang)}."}],
+        )
+        first_q = resp.choices[0].message.content.strip()
+        session.last_teacher_text = first_q
+        greeting = "Let's start with a quick check!" if lang == "en" else "まずは軽いチェックから始めましょう！"
+        return {
+            "session_id": sid,
+            "teacher_name": teacher.config.name,
+            "teacher_message": f"{greeting}\n\n{first_q}",
+            "session_phase": "pre_test",
+            "test_progress": f"1/{NUM_TEST_QUESTIONS}",
+            "is_complete": False,
+        }
+
+    # No pre-test: open with a teaching greeting and let the student speak first.
+    greeting = (
+        f"Hi! I'm {teacher.config.name}. What would you like to work on for {display_topic(topic, lang)}?"
+        if lang == "en"
+        else f"こんにちは！{teacher.config.name}です。{display_topic(topic, lang)}について、どこから始めましょうか？"
     )
-    first_q = resp.choices[0].message.content.strip()
-    session.last_teacher_text = first_q
-
-    greeting = "Let's start with a quick check!" if lang == "en" else "まずは軽いチェックから始めましょう！"
-
+    session.last_teacher_text = greeting
     return {
         "session_id": sid,
         "teacher_name": teacher.config.name,
-        "teacher_message": f"{greeting}\n\n{first_q}",
-        "session_phase": "pre_test",
-        "test_progress": f"1/{NUM_TEST_QUESTIONS}",
+        "teacher_message": greeting,
+        "session_phase": "teaching",
+        "test_progress": None,
         "is_complete": False,
     }
 
@@ -632,7 +661,11 @@ async def live_respond(session_id: str, body: dict):
 
 @app.post("/api/live/{session_id}/end")
 async def live_end(session_id: str):
-    """Human student explicitly ends the session → jump to post-test."""
+    """Human student explicitly ends the session.
+
+    Default path: jump to post-test. If the session was started with
+    `run_post_test: false` (#34), skip post-test and complete immediately.
+    """
     session = LIVE_SESSIONS.get(session_id)
     if not session:
         raise HTTPException(404, "session not found or expired")
@@ -640,6 +673,33 @@ async def live_end(session_id: str):
         raise HTTPException(400, "session already complete")
     if session.session_phase not in ("teaching", "pre_test"):
         raise HTTPException(400, f"cannot end from phase {session.session_phase}")
+
+    # Skip post-test path
+    if not session.run_post_test:
+        session.is_complete = True
+        session.session_phase = "complete"
+        if session.turns_log:
+            sorted_turns = sorted(session.turns_log, key=lambda t: t.get("delta", 0), reverse=True)
+            session.key_moments = [
+                {"turn": t["turn"], "phase": t["phase_label"], "delta": t["delta"], "summary": t["summary"]}
+                for t in sorted_turns[:3] if t.get("delta", 0) > 0
+            ]
+        _save_live_session(session)
+        pre_score = sum(1 for r in session.pre_test_results if r["correct"])
+        farewell = ("Nice work today!" if session.lang == "en"
+                    else "今日もよく頑張りました！")
+        return {
+            "teacher_message": farewell,
+            "session_phase": "complete",
+            "is_complete": True,
+            "pre_test": session.pre_test_results,
+            "post_test": [],
+            "pre_score": f"{pre_score}/{NUM_TEST_QUESTIONS}" if session.run_pre_test else None,
+            "post_score": None,
+            "improvement": None,
+            "key_moments": session.key_moments,
+            "proficiency_delta": round(session.proficiency - session.initial_proficiency, 1),
+        }
 
     from openai import OpenAI
     client = OpenAI()

--- a/training_field/web/templates/session.html
+++ b/training_field/web/templates/session.html
@@ -373,25 +373,11 @@ body{
 .mode-btn.active{background:var(--text);color:var(--bg)}
 .mode-btn:not(.active):hover{background:var(--surface-2);color:var(--text)}
 
-.measure-toggle{
-  display:flex;align-items:center;gap:10px;
-  font-size:13px;color:var(--text-secondary);font-weight:500;
-  cursor:pointer;user-select:none;letter-spacing:-0.01em;
-  padding:0 8px;
+.measure-note{
+  display:flex;align-items:center;
+  font-size:12px;color:var(--text-muted, var(--text-secondary));
+  font-style:italic;padding:0 8px;letter-spacing:-0.01em;
 }
-.measure-toggle input{position:absolute;opacity:0;pointer-events:none}
-.measure-box{
-  width:20px;height:20px;border-radius:6px;
-  border:1.5px solid var(--border-strong);
-  background:var(--surface);
-  display:flex;align-items:center;justify-content:center;
-  transition:background-color .2s var(--ease),border-color .2s var(--ease);
-  color:var(--bg);
-}
-.measure-box svg{width:12px;height:12px;opacity:0;transition:opacity .15s var(--ease)}
-.measure-toggle input:checked + .measure-box{background:var(--text);border-color:var(--text)}
-.measure-toggle input:checked + .measure-box svg{opacity:1}
-.measure-toggle:hover .measure-box{border-color:var(--text)}
 
 /* ── Skills chips ─────────────────────────────────── */
 .sk{
@@ -538,11 +524,9 @@ select:hover{border-color:var(--text)}
     </div>
   </div>
   <div class="bbar">
-    <label class="measure-toggle" id="measureWrap">
-      <input type="checkbox" id="measureChk">
-      <span class="measure-box"><svg viewBox="0 0 12 12" fill="none"><path d="M2.5 6.5L5 9L9.5 3.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
-      <span data-i18n="measure_learning">Measure learning (pre/post test)</span>
-    </label>
+    <div class="measure-note" id="measureNote">
+      <span data-i18n="measure_always_on">Pre/Post tests always run (required to compare teachers — see #34)</span>
+    </div>
     <button class="btn-run" id="brun" onclick="runSession()" data-i18n="start_session">Start Session</button>
   </div>
 </div>
@@ -618,7 +602,7 @@ const I18N = {
     eval_axes:"評価軸", ax_system:"システム", ax_prof:"習熟度", ax_dialog:"対話品質", ax_goal:"目標達成", ax_pass:"合格点",
     sys_metrics:"システム指標", halluc_rate:"幻覚発生率", direct_rate:"直接回答率", avg_zpd:"平均ZPD", avg_bloom:"平均Bloom",
     session_hist:"セッション履歴", no_sessions:"セッションなし",
-    select_unit:"単元を選択してセッションを開始", start_session:"セッション開始", run_test:"テスト実施", measure_learning:"学習効果を測定 (pre/post test)",
+    select_unit:"単元を選択してセッションを開始", start_session:"セッション開始", run_test:"テスト実施", measure_always_on:"事前・事後テストは常に実施（比較のため必須）",
     topic:"単元", depth:"深さ", skills_lib:"スキルライブラリ",
     teacher_agent:"教師エージェント", student_agent:"生徒エージェント", referee:"審判",
     neutral_eval:"中立評価 — 全Agentに適用",
@@ -630,7 +614,7 @@ const I18N = {
     eval_axes:"Evaluation Axes", ax_system:"System", ax_prof:"Proficiency", ax_dialog:"Dialog Quality", ax_goal:"Goal Achieved", ax_pass:"Pass Score",
     sys_metrics:"System Metrics", halluc_rate:"Hallucination Rate", direct_rate:"Direct Answer Rate", avg_zpd:"avg ZPD", avg_bloom:"avg Bloom",
     session_hist:"Session History", no_sessions:"No sessions yet",
-    select_unit:"Select a topic to start a session", start_session:"Start Session", run_test:"Run Test", measure_learning:"Measure learning (pre/post test)",
+    select_unit:"Select a topic to start a session", start_session:"Start Session", run_test:"Run Test", measure_always_on:"Pre/post tests always run (required to compare teachers)",
     topic:"Topic", depth:"Depth", skills_lib:"Skills Library",
     teacher_agent:"Teacher Agent", student_agent:"Student Agent", referee:"Referee",
     neutral_eval:"Neutral evaluation — applied to all Agents",
@@ -885,15 +869,17 @@ function setMode(m){
   sessionMode = m;
   document.getElementById("modeAI").className = "mode-btn" + (m==="ai"?" active":"");
   document.getElementById("modeLive").className = "mode-btn" + (m==="live"?" active":"");
-  document.getElementById("measureWrap").style.display = m==="ai"?"flex":"none";
+  const note = document.getElementById("measureNote");
+  if(note) note.style.display = m==="ai"?"flex":"none";
 }
 
 function runSession(){
   if(sessionMode === "live") return startLiveSession();
-  const measure = document.getElementById("measureChk").checked;
+  // Observatory (agent vs agent) sessions always run pre/post tests
+  // so results are comparable across teachers. See #34.
   startStream({
-    pre_test: measure, post_test: measure,
-    statusKey: measure ? "status_test" : "status_running",
+    pre_test: true, post_test: true,
+    statusKey: "status_test",
   });
 }
 


### PR DESCRIPTION
## 概要 / Summary
2つのセッション入口で別々のデフォルト挙動を明確化:
- **Observatory (AI同士)**: Pre/Post **必須**、チェックボックス撤廃
- **Live (実生徒)**: Pre/Post がデフォルト ON、\`run_pre_test\` / \`run_post_test\` フラグで opt-out 可能

## なぜ / Why
- Observatory は「教師を比較する」ことが目的で、Pre/Post がないと比較が成り立たない。テストなし選択肢は意味がなく、バグの温床（#21系）
- 実生徒側では #28 が「範囲指定したら pre_test skip」というフローを提案中。そのための API 基盤が必要

## 変更 / Changes

### \`training_field/web/templates/session.html\` — Observatory
- \`measureChk\` / \`measureWrap\` チェックボックス削除
- 代わりに inline note（"Pre/post tests always run — required to compare teachers"）
- CSS \`.measure-toggle\` / \`.measure-box\` 関連を削除、\`.measure-note\` を新設
- \`runSession()\` は常に \`pre_test: true, post_test: true\` を渡す

### \`training_field/web/app.py\` — Live session
- \`LiveSession\` dataclass に \`run_pre_test\`, \`run_post_test\` (両方 default=True) を追加
- \`POST /api/live/start\` が body の \`run_pre_test\` / \`run_post_test\` を受けるように
  - \`run_pre_test=false\` → 初期 phase を \`"teaching"\` にして、挨拶メッセージで開始
  - デフォルト挙動は完全互換（既存クライアントは影響なし）
- \`POST /api/live/{id}/end\` が \`run_post_test=false\` のとき post-test をスキップして直接 complete

## スコープ外（#34ではやらない）/ Out of Scope
- **UI 側の "範囲指定して pre_test skip" ボタン/フロー** — これは #28 で実装
- **既存 Live session UI の変更** — 現時点で \`learn_session.html\` はチェックボックスを持っておらず、デフォルトのまま動く

## 検証 / Testing
- [x] py_compile OK
- [x] テンプレート構文チェック
- [x] デフォルト（フラグ未指定）で既存挙動を維持することを確認
- [ ] \`run_pre_test=false\` で teaching phase 開始するか実動作確認（deploy 後）
- [ ] \`run_post_test=false\` で /end が即 complete を返すか実動作確認（deploy 後）
- [ ] Observatory で Pre/Post が常に走るか確認（deploy 後）

## 関連 / Related
Closes #34
- #28（範囲指定+pre_test skip）の API 基盤
- #35（デルタベース評価）との整合（テストなしパスも適切にgradingされる）