### PR TITLE
[Feature] Learning-scope input skips the pre-test (fixes #28)

### DIFF
--- a/training_field/web/app.py
+++ b/training_field/web/app.py
@@ -355,6 +355,10 @@ async def live_start(body: dict):
     student_label = body.get("student_name", "You")
     run_pre_test = bool(body.get("run_pre_test", True))
     run_post_test = bool(body.get("run_post_test", True))
+    # Optional learning scope the student specified (#28). When present we
+    # skip the pre-test and weave the scope into the teacher's greeting so
+    # the first message is relevant to what the student actually wants.
+    scope = (body.get("scope") or "").strip() or None
 
     gcode = GRADE_CODES.get(grade_str, 6)
     teacher = load_teacher(teacher_id)
@@ -405,12 +409,29 @@ async def live_start(body: dict):
             "is_complete": False,
         }
 
-    # No pre-test: open with a teaching greeting and let the student speak first.
-    greeting = (
-        f"Hi! I'm {teacher.config.name}. What would you like to work on for {display_topic(topic, lang)}?"
-        if lang == "en"
-        else f"こんにちは！{teacher.config.name}です。{display_topic(topic, lang)}について、どこから始めましょうか？"
-    )
+    # No pre-test: open with a teaching greeting. If the student gave us a
+    # scope (#28), acknowledge it and dive straight into it instead of
+    # asking an open "what do you want to work on?" question.
+    dtopic = display_topic(topic, lang)
+    if scope:
+        if lang == "en":
+            greeting = (
+                f"Hi! I'm {teacher.config.name}. Got it — let's work on "
+                f"\"{scope}\" for {dtopic}. Let me start with a quick "
+                f"walkthrough, and jump in any time you want to ask something."
+            )
+        else:
+            greeting = (
+                f"こんにちは！{teacher.config.name}です。"
+                f"「{scope}」ですね。{dtopic}について、一緒に見ていきましょう。"
+                f"途中でわからないところがあったら、気軽に聞いてくださいね。"
+            )
+    else:
+        greeting = (
+            f"Hi! I'm {teacher.config.name}. What would you like to work on for {dtopic}?"
+            if lang == "en"
+            else f"こんにちは！{teacher.config.name}です。{dtopic}について、どこから始めましょうか？"
+        )
     session.last_teacher_text = greeting
     return {
         "session_id": sid,

--- a/training_field/web/templates/learn.html
+++ b/training_field/web/templates/learn.html
@@ -158,6 +158,15 @@ h1{font-size:28px;font-weight:600;letter-spacing:-0.025em;margin-bottom:8px}
       {% endfor %}
     </select>
   </div>
+  <div class="form-group">
+    <label class="form-label" data-i18n="label_scope">LEARNING SCOPE (OPTIONAL)</label>
+    <input type="text" class="form-select" id="scopeInput"
+           data-i18n-placeholder="scope_placeholder"
+           placeholder='e.g. "textbook p.42 word problems" — leave blank to take a pre-test first' />
+    <div class="form-hint" data-i18n="scope_hint" style="font-size:11px;color:var(--muted);margin-top:4px">
+      When you tell the teacher what you want to work on, the session skips the pre-test and jumps straight into teaching.
+    </div>
+  </div>
   <button class="btn-primary" onclick="startSession()" data-i18n="start_session">Start Session</button>
 
   <div class="history-list" id="historyList"></div>
@@ -177,6 +186,9 @@ const I18N = {
     label_name:"なまえ", name_placeholder:"例：エマ",
     label_grade:"がくねん", label_subject:"きょうか", label_teacher:"せんせい",
     label_progress:"これまでの学習", label_topic:"単元",
+    label_scope:"学習したい範囲（任意）",
+    scope_placeholder:"例：「教科書p.42の例題」「分数の割り算だけ」— 空欄なら事前テストから始めます",
+    scope_hint:"範囲を書くと事前テストをスキップして、すぐに解説から始まります。",
     lets_go:"はじめる", start_session:"セッション開始", switch_student:"別の生徒に切り替え",
     welcome_back:n=>"おかえりなさい、"+n+"さん！",
     welcome_sub:(g,s,n)=>g+" · "+s+" · "+n+" セッション完了",
@@ -190,6 +202,9 @@ const I18N = {
     label_name:"YOUR NAME", name_placeholder:"e.g. Emma",
     label_grade:"GRADE", label_subject:"SUBJECT", label_teacher:"TEACHER",
     label_progress:"YOUR PROGRESS", label_topic:"TOPIC",
+    label_scope:"LEARNING SCOPE (OPTIONAL)",
+    scope_placeholder:'e.g. "textbook p.42 word problems" — leave blank to take a pre-test first',
+    scope_hint:"When you tell the teacher what you want to work on, the session skips the pre-test and jumps straight into teaching.",
     lets_go:"Let's Go", start_session:"Start Session", switch_student:"Switch student",
     welcome_back:n=>"Welcome back, "+n+"!",
     welcome_sub:(g,s,n)=>g+" · "+s+" · "+n+" sessions completed",
@@ -356,10 +371,14 @@ function startSession(){
   const sid = localStorage.getItem("tfStudentId");
   const teacher = document.getElementById("teacherSelect").value;
   const topic = document.getElementById("topicSelect").value;
+  const scopeEl = document.getElementById("scopeInput");
+  const scope = (scopeEl && scopeEl.value || "").trim();
   localStorage.setItem("tfStudentTeacher", teacher);
-  window.location.href = "/learn/session?student_id="+sid+
+  let url = "/learn/session?student_id="+sid+
     "&teacher_id="+encodeURIComponent(teacher)+
     "&topic="+encodeURIComponent(topic);
+  if(scope) url += "&scope="+encodeURIComponent(scope);
+  window.location.href = url;
 }
 
 function goToSession(profile, teacherId){

--- a/training_field/web/templates/learn_session.html
+++ b/training_field/web/templates/learn_session.html
@@ -372,6 +372,11 @@ const TOPIC = params.get("topic") || "分数のかけ算とわり算";
 const DEPTH = params.get("depth") || "standard";
 const GRADE = localStorage.getItem("tfStudentGrade") || "小6";
 const SUBJECT = localStorage.getItem("tfStudentSubject") || "算数";
+// Optional scope the student provided (e.g. "教科書p.42の例題" / "分数の割り算だけ").
+// When present, we skip the pre-test and open straight into teaching — the
+// student has already told us what they want to work on. See #28.
+const SCOPE = (params.get("scope") || "").trim();
+const SKIP_PRETEST = SCOPE.length > 0;
 
 const I18N = {
   ja: {
@@ -690,14 +695,22 @@ async function initSession(){
         teacher_id: TEACHER_ID, topic: TOPIC, depth: DEPTH,
         grade: GRADE, subject: SUBJECT, lang: curLang,
         student_name: studentName,
+        run_pre_test: !SKIP_PRETEST,
+        scope: SCOPE || null,
       }),
     });
     const d = await res.json();
     if(!res.ok) throw new Error(d.detail||"start failed");
     sessionId = d.session_id;
     startProgressTracking();
-    showTestBanner("pre");
-    await showTeacherMsg(d.teacher_message, {testKind: "pre", testProgress: d.test_progress});
+    if(SKIP_PRETEST){
+      // No pre-test: the teacher opens with a teaching greeting.
+      lastSessionPhase = "teaching";
+      await showTeacherMsg(d.teacher_message, {});
+    } else {
+      showTestBanner("pre");
+      await showTeacherMsg(d.teacher_message, {testKind: "pre", testProgress: d.test_progress});
+    }
     // Enable input
     document.getElementById("inputField").disabled = false;
     document.getElementById("sendBtn").disabled = false;


### PR DESCRIPTION
## 概要 / Summary
生徒が「学習したい範囲」を指定したら、事前テストをスキップしていきなり解説フェーズから始まる導線を実装。

## フロー / Flow
1. \`/learn\` で生徒が Topic と Teacher を選び、**新規追加のスコープ入力欄** に "教科書p.42の例題" のような自由記述を入れる（任意）
2. 空欄で \`Start Session\` → 従来通り事前テストから開始
3. スコープ記入あり → 事前テストスキップ、Teacher が「"○○"ですね。一緒に見ていきましょう…」と挨拶してそのまま解説へ

## 変更 / Changes
- **\`learn.html\`**: オプションの "Learning Scope" 入力欄 + 説明文（ja/en）。入力ありなら session URL に \`?scope=...\` を付けて遷移
- **\`learn_session.html\`**: URL から \`SCOPE\` を取得。値があれば \`run_pre_test: false\` + \`scope\` を \`/api/live/start\` に送り、\`session_phase\` を \`teaching\` 直行（pre-test バナーをスキップ）
- **\`app.py /api/live/start\`**: body の \`scope\` を受け取り、pre-test スキップ時のあいさつに scope を織り込む。スコープ無し or 従来呼び出しは挙動変化なし

## 依存 / Depends on
- #34（\`run_pre_test\` フラグ対応）— マージ済み

## 検証 / Testing
- [x] py_compile OK
- [x] スコープ空欄の従来フローは完全互換（URL に scope が付かず、API body も従来通り）
- [ ] Live app: スコープ記入 → pre-test がスキップされるか（deploy 後）
- [ ] Live app: Teacher の挨拶にスコープ文言が入るか
- [ ] Live app: \`/api/live/{id}/end\` で post-test は通常通り走るか（run_post_test はデフォルト true のまま）

## 関連 / Related
Closes #28
- #34（Pre/Post 必須化・選択可再設計）の UX 実装
- #32（宿題写真アップロード）の API 基盤も兼ねる（scope にOCR結果を渡せる）
- #33（学習単元の柔軟な入力対応）と補完関係