### PR TITLE
[Feature] End-of-session student feedback on the teacher (fixes #29)

### DIFF
--- a/training_field/web/app.py
+++ b/training_field/web/app.py
@@ -802,6 +802,50 @@ async def live_feedback(session_id: str, body: dict):
     return {"ok": True, "count": len(log["entries"])}
 
 
+@app.post("/api/live/{session_id}/session-feedback")
+async def live_session_feedback(session_id: str, body: dict):
+    """Record the student's end-of-session feedback on the teacher (#29).
+
+    body: {rating?: 1-5, tags?: [str], note?: str, action: "submit"|"skip"}
+    Stored at reports/feedback/{session_id}_session.json. Rating and tags
+    are both optional so the student can submit just a note, just stars,
+    or skip entirely. The skip action is recorded so we know the form
+    was shown and dismissed (distinct from "never saw it").
+    """
+    session = LIVE_SESSIONS.get(session_id)
+    action = body.get("action", "submit")
+    if action not in ("submit", "skip"):
+        raise HTTPException(400, "action must be 'submit' or 'skip'")
+    rating = body.get("rating")
+    if rating is not None:
+        try:
+            rating = int(rating)
+        except (TypeError, ValueError):
+            raise HTTPException(400, "rating must be an integer 1-5 or null")
+        if not 1 <= rating <= 5:
+            raise HTTPException(400, "rating must be between 1 and 5")
+    tags = body.get("tags") or []
+    if not isinstance(tags, list):
+        raise HTTPException(400, "tags must be a list")
+    tags = [str(t)[:60] for t in tags][:20]
+    note = (body.get("note") or "")[:2000]
+
+    FEEDBACK_DIR.mkdir(parents=True, exist_ok=True)
+    path = FEEDBACK_DIR / f"{session_id}_session.json"
+    payload = {
+        "session_id": session_id,
+        "action": action,
+        "rating": rating,
+        "tags": tags,
+        "note": note,
+        "teacher_id": session.teacher.config.teacher_id if session else None,
+        "topic": session.topic if session else None,
+        "timestamp": datetime.datetime.now().isoformat(),
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return {"ok": True}
+
+
 @app.get("/api/live/{session_id}")
 async def live_status(session_id: str):
     """Get current state of a live session."""

--- a/training_field/web/templates/learn_session.html
+++ b/training_field/web/templates/learn_session.html
@@ -415,6 +415,16 @@ const I18N = {
     fb_up_title:"わかりやすかった",
     fb_confused_title:"よくわからない",
     fb_down_title:"わかりにくい",
+    fb_session_title:"今日の先生はどうでしたか？",
+    fb_tag_clarity:"説明がわかりやすい",
+    fb_tag_pace:"ペースがちょうどよい",
+    fb_tag_difficulty:"難易度がちょうどよい",
+    fb_tag_tone:"話し方が好き",
+    fb_tag_patience:"待ってくれる",
+    fb_placeholder:"もっと書きたいことがあれば（任意）",
+    fb_submit:"フィードバック送信",
+    fb_skip:"スキップ",
+    fb_thanks:"ありがとう！参考にします。",
     progress_turn:"ターン",
     milestone_icon:"🎯",
     milestone_title:(n)=>n+"ターン続いたよ！順調です。",
@@ -458,6 +468,16 @@ const I18N = {
     fb_up_title:"Clear and helpful",
     fb_confused_title:"Not sure I follow",
     fb_down_title:"Not helpful",
+    fb_session_title:"How was your teacher today?",
+    fb_tag_clarity:"Clear explanations",
+    fb_tag_pace:"Good pace",
+    fb_tag_difficulty:"Right difficulty",
+    fb_tag_tone:"Liked the tone",
+    fb_tag_patience:"Patient with me",
+    fb_placeholder:"Anything else you want to share? (optional)",
+    fb_submit:"Send feedback",
+    fb_skip:"Skip",
+    fb_thanks:"Thanks! We'll use this.",
     progress_turn:"Turn",
     milestone_icon:"🎯",
     milestone_title:(n)=>"You've talked for "+n+" turns — great job!",
@@ -850,6 +870,27 @@ function showReview(d){
     reviewHTML += '</div>';
   }
 
+  // Session feedback form (#29): let the student rate how the teacher taught
+  reviewHTML += '<div class="session-fb" style="margin-top:28px;padding-top:20px;border-top:1px solid var(--border)">';
+  reviewHTML += '<div style="font-size:11px;font-weight:600;color:var(--muted);letter-spacing:0.04em;margin-bottom:10px">'+t("fb_session_title")+'</div>';
+  reviewHTML += '<div class="fb-stars" style="display:flex;gap:6px;margin-bottom:12px;justify-content:center">';
+  for(let i=1;i<=5;i++){
+    reviewHTML += '<button class="fb-star" data-val="'+i+'" type="button" style="background:none;border:none;font-size:26px;cursor:pointer;color:var(--border-strong);transition:color .15s">☆</button>';
+  }
+  reviewHTML += '</div>';
+  reviewHTML += '<div class="fb-tags" style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:12px;justify-content:center">';
+  ["fb_tag_clarity","fb_tag_pace","fb_tag_difficulty","fb_tag_tone","fb_tag_patience"].forEach(key=>{
+    reviewHTML += '<button class="fb-tag" data-key="'+key+'" type="button" style="font-size:11px;padding:4px 10px;border-radius:12px;border:1px solid var(--border-strong);background:none;color:var(--text-secondary);cursor:pointer">'+t(key)+'</button>';
+  });
+  reviewHTML += '</div>';
+  reviewHTML += '<textarea class="fb-note" placeholder="'+t("fb_placeholder")+'" style="width:100%;min-height:60px;padding:10px;border-radius:8px;border:1px solid var(--border);background:var(--surface);font-family:inherit;font-size:13px;resize:vertical"></textarea>';
+  reviewHTML += '<div class="fb-actions" style="display:flex;gap:10px;justify-content:center;margin-top:14px">';
+  reviewHTML += '<button class="fb-submit complete-btn" type="button">'+t("fb_submit")+'</button>';
+  reviewHTML += '<button class="fb-skip" type="button" style="background:none;border:none;color:var(--muted);font-size:12px;cursor:pointer">'+t("fb_skip")+'</button>';
+  reviewHTML += '</div>';
+  reviewHTML += '<div class="fb-thanks" style="display:none;text-align:center;font-size:13px;color:var(--success);margin-top:10px">'+t("fb_thanks")+'</div>';
+  reviewHTML += '</div>';
+
   reviewHTML += '<div style="text-align:center;margin-top:28px"><a href="/learn" class="complete-btn">'+t("continue_learning")+'</a></div>';
   reviewHTML += '</div>';
 
@@ -857,9 +898,70 @@ function showReview(d){
   card.innerHTML = reviewHTML;
   chat.appendChild(card.firstChild);
   chat.scrollTop = chat.scrollHeight;
+  wireSessionFeedback(chat);
 }
 
 function escHtml(s){return (s||"").replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));}
+
+// ── Session feedback (#29) ───────────────────────
+function wireSessionFeedback(scope){
+  const root = scope.querySelector(".session-fb");
+  if(!root) return;
+  let rating = 0;
+  const tags = new Set();
+  const stars = root.querySelectorAll(".fb-star");
+  stars.forEach(btn=>{
+    btn.onclick = ()=>{
+      rating = parseInt(btn.dataset.val, 10);
+      stars.forEach(s=>{
+        const v = parseInt(s.dataset.val, 10);
+        s.textContent = v <= rating ? "★" : "☆";
+        s.style.color = v <= rating ? "#f59e0b" : "var(--border-strong)";
+      });
+    };
+  });
+  root.querySelectorAll(".fb-tag").forEach(btn=>{
+    btn.onclick = ()=>{
+      const k = btn.dataset.key;
+      if(tags.has(k)){
+        tags.delete(k);
+        btn.style.background = "none";
+        btn.style.color = "var(--text-secondary)";
+      } else {
+        tags.add(k);
+        btn.style.background = "var(--link-bg, rgba(0,113,227,0.12))";
+        btn.style.color = "var(--link, #2997ff)";
+      }
+    };
+  });
+  const thanks = root.querySelector(".fb-thanks");
+  const actions = root.querySelector(".fb-actions");
+  const submit = root.querySelector(".fb-submit");
+  const skip = root.querySelector(".fb-skip");
+  const note = root.querySelector(".fb-note");
+  async function finalize(reason){
+    // hide form, show thanks (or nothing on pure skip)
+    if(actions) actions.style.display = "none";
+    stars.forEach(s=>s.disabled = true);
+    root.querySelectorAll(".fb-tag").forEach(t=>t.disabled = true);
+    if(note) note.disabled = true;
+    if(reason === "submit" && thanks) thanks.style.display = "block";
+    try {
+      await fetch("/api/live/"+sessionId+"/session-feedback", {
+        method:"POST",
+        headers:{"Content-Type":"application/json"},
+        body: JSON.stringify({
+          rating: rating || null,
+          tags: Array.from(tags),
+          note: (note && note.value || "").trim(),
+          action: reason,
+        }),
+      });
+    } catch(e){ /* best-effort; don't block navigation */ }
+  }
+  if(submit) submit.onclick = ()=>finalize("submit");
+  if(skip) skip.onclick = ()=>finalize("skip");
+}
 
 // ── Quick actions (teaching phase) ───────────────
 function updateQuickActions(){


### PR DESCRIPTION
## 概要 / Summary
セッション終了後の完了画面に、生徒がTeacherの教え方をフィードバックできるフォームを追加。

## なぜ / Why
- #13 でターン単位の 👍/❓/👎 はあるが、セッション全体を通した「教え方」のフィードバックを集める場がなかった
- Teacher Memory (#14) や将来の教師選択改善 (#10) に、総合評価シグナルが必要
- テストスコアだけでは「教え方が生徒に合ったか」は測れない

## UI（完了画面に追加）
- **星評価 (1-5)** — 任意
- **タグチップ** — 複数選択可、任意
  - 説明がわかりやすい / ペースがちょうどよい / 難易度がちょうどよい / 話し方が好き / 待ってくれる
- **自由記述** — 任意、2000字上限
- **送信 / スキップ** ボタン — 両方とも記録（"dismissed" と "never shown" を区別）
- 送信後はサンクスメッセージ表示、フォームはロック

## API
\`POST /api/live/{session_id}/session-feedback\`
- body: \`{rating?: 1-5, tags?: [str], note?: str, action: "submit"|"skip"}\`
- 全フィールド optional（星だけ、ノートだけ、等でもOK）
- rating は 1-5 の int 検証、tags は 20個上限・各60字、note は 2000字
- 保存先: \`reports/feedback/{session_id}_session.json\`（#13 の turn 単位とは別ファイル）
- LiveSession が GC 済みでも受け付ける（遅延送信対応）

## 変更 / Changes
- \`training_field/web/app.py\`: 新エンドポイント追加
- \`training_field/web/templates/learn_session.html\`:
  - 完了画面に feedback form の HTML 追加
  - \`wireSessionFeedback()\` で interactive behavior 配線
  - ja/en i18n キー追加（11個）

## 検証 / Testing
- [x] py_compile OK
- [x] テンプレート構文チェック
- [x] 星・タグ・ノートがすべて optional で、どれか一つだけでも送信できる
- [ ] Live: 完了画面で form が描画される（deploy 後）
- [ ] Live: send → JSON ファイルが \`reports/feedback/{id}_session.json\` に保存される
- [ ] Live: skip → action="skip" で保存される

## 関連 / Related
Closes #29
- #13（ターン単位フィードバック）と姉妹関係
- #14（Teacher Memory）、#10（教師選択ガイド）のシグナル源
- #30（保護者による教え方調整 — 議論）の前提データ