### PR TITLE
[Feature] Student progress dashboard on /learn (fixes #8)

### DIFF
--- a/training_field/web/app.py
+++ b/training_field/web/app.py
@@ -970,15 +970,67 @@ async def student_register(body: dict):
 
 @app.get("/api/student/{student_id}")
 async def student_get(student_id: str):
-    """Get a real student's profile + session history."""
+    """Get a real student's profile + session history + computed stats (#8)."""
     path = STUDENT_PROFILES_DIR / f"{student_id}.json"
     if not path.exists():
         raise HTTPException(404, "student not found")
     profile = json.loads(path.read_text(encoding="utf-8"))
     reg = ExperimentRegistry()
-    history = reg.query(filter_by={"student_id": student_id}, limit=20)
+    history = reg.query(filter_by={"student_id": student_id}, limit=50)
     profile["history"] = history
+    profile["stats"] = _compute_student_stats(history)
     return profile
+
+
+def _compute_student_stats(history: list) -> dict:
+    """Compute streak + per-topic progress deltas from session history."""
+    # Streak: count distinct calendar days (descending from most recent) where
+    # at least one session exists, stopping at the first gap of >1 day.
+    days = set()
+    for h in history:
+        ts = h.get("timestamp") or ""
+        day = ts[:10]  # YYYY-MM-DD
+        if day:
+            days.add(day)
+    sorted_days = sorted(days, reverse=True)
+    streak = 0
+    if sorted_days:
+        try:
+            cur = datetime.date.fromisoformat(sorted_days[0])
+            today = datetime.date.today()
+            # Only count streak if most recent day is today or yesterday.
+            if (today - cur).days <= 1:
+                for d_str in sorted_days:
+                    d = datetime.date.fromisoformat(d_str)
+                    if d == cur:
+                        streak += 1
+                        cur -= datetime.timedelta(days=1)
+                    elif d < cur:
+                        break
+        except (ValueError, TypeError):
+            streak = 0
+
+    # Per-topic delta trend: last 5 sessions grouped by topic, showing
+    # proficiency_delta each time. Useful for spark-line display.
+    topic_trend: dict[str, list] = {}
+    for h in reversed(history):  # oldest first
+        topic = h.get("topic")
+        delta = h.get("proficiency_delta")
+        if topic and delta is not None:
+            topic_trend.setdefault(topic, []).append(round(delta, 1))
+    for t in topic_trend:
+        topic_trend[t] = topic_trend[t][-5:]  # keep last 5 per topic
+
+    total_delta = sum(
+        h.get("proficiency_delta") or 0 for h in history
+    )
+    return {
+        "streak_days": streak,
+        "sessions_total": len(history),
+        "total_proficiency_gain": round(total_delta, 1),
+        "topic_trend": topic_trend,
+        "last_session_at": history[0].get("timestamp") if history else None,
+    }
 
 @app.post("/api/student/{student_id}/update-proficiency")
 async def student_update_prof(student_id: str, body: dict):

--- a/training_field/web/templates/learn.html
+++ b/training_field/web/templates/learn.html
@@ -104,6 +104,35 @@ h1{font-size:28px;font-weight:600;letter-spacing:-0.025em;margin-bottom:8px}
   background:var(--surface-2);color:var(--text-secondary);
   font-weight:500;font-feature-settings:"tnum";
 }
+
+/* Dashboard stats (#8) */
+.stats-grid{
+  display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin:16px 0 24px;
+}
+.stats-card{
+  padding:14px 16px;border-radius:12px;background:var(--surface-2);
+  display:flex;flex-direction:column;gap:4px;
+}
+.stats-num{font-size:24px;font-weight:600;letter-spacing:-0.02em;font-feature-settings:"tnum"}
+.stats-num.streak{color:#f59e0b}
+.stats-num.sessions{color:var(--link, #2997ff)}
+.stats-num.gain{color:var(--success)}
+.stats-label{font-size:10px;color:var(--muted);text-transform:uppercase;letter-spacing:0.05em}
+.trend-list{margin-bottom:24px}
+.trend-row{
+  display:flex;align-items:center;gap:10px;padding:8px 0;
+  border-bottom:1px solid var(--border);font-size:12px;
+}
+.trend-row:last-child{border-bottom:none}
+.trend-topic{flex:1;color:var(--text-secondary)}
+.trend-spark{display:flex;gap:3px;align-items:flex-end;height:20px}
+.trend-bar{
+  width:4px;border-radius:2px;background:var(--border-strong);
+  min-height:2px;
+}
+.trend-bar.pos{background:var(--success)}
+.trend-bar.neg{background:var(--danger)}
+.trend-sum{font-size:11px;color:var(--muted);font-feature-settings:"tnum";min-width:40px;text-align:right}
 </style>
 </head>
 <body>
@@ -143,8 +172,14 @@ h1{font-size:28px;font-weight:600;letter-spacing:-0.025em;margin-bottom:8px}
   <div class="welcome" id="welcomeMsg">Welcome back!</div>
   <div class="welcome-sub" id="welcomeSub"></div>
 
+  <!-- Dashboard stats (#8) — streak / total sessions / total gain -->
+  <div class="stats-grid" id="statsGrid" style="display:none"></div>
+
   <div class="form-label" data-i18n="label_progress">YOUR PROGRESS</div>
   <div class="prof-grid" id="profGrid"></div>
+
+  <!-- Per-topic trend (#8): last-5 deltas as mini sparkline -->
+  <div class="trend-list" id="trendList"></div>
 
   <div class="form-group">
     <label class="form-label" data-i18n="label_topic">TOPIC</label>
@@ -195,6 +230,9 @@ const I18N = {
     scope_hint:"範囲を書くと事前テストをスキップして、すぐに解説から始まります。",
     topic_other:"その他（自由記述）",
     topic_custom_placeholder:"例：「割合の文章題」「百分率の計算」",
+    stat_streak:"連続日数",
+    stat_sessions:"セッション数",
+    stat_total_gain:"累計の伸び",
     lets_go:"はじめる", start_session:"セッション開始", switch_student:"別の生徒に切り替え",
     welcome_back:n=>"おかえりなさい、"+n+"さん！",
     welcome_sub:(g,s,n)=>g+" · "+s+" · "+n+" セッション完了",
@@ -213,6 +251,9 @@ const I18N = {
     scope_hint:"When you tell the teacher what you want to work on, the session skips the pre-test and jumps straight into teaching.",
     topic_other:"Other (type your own)",
     topic_custom_placeholder:'e.g. "word problems about ratios"',
+    stat_streak:"Day streak",
+    stat_sessions:"Sessions",
+    stat_total_gain:"Total gain",
     lets_go:"Let's Go", start_session:"Start Session", switch_student:"Switch student",
     welcome_back:n=>"Welcome back, "+n+"!",
     welcome_sub:(g,s,n)=>g+" · "+s+" · "+n+" sessions completed",
@@ -326,6 +367,26 @@ function showWelcome(profile){
   document.getElementById("welcomeMsg").textContent = tr("welcome_back")(profile.name);
   document.getElementById("welcomeSub").textContent = tr("welcome_sub")(profile.grade, profile.subject, profile.sessions_completed);
 
+  // Dashboard stats (#8): streak / total sessions / proficiency gain
+  const stats = profile.stats || {};
+  const statsGrid = document.getElementById("statsGrid");
+  if(statsGrid && (stats.sessions_total || 0) > 0){
+    statsGrid.innerHTML =
+      '<div class="stats-card">'+
+        '<div class="stats-num streak">'+(stats.streak_days||0)+'</div>'+
+        '<div class="stats-label">'+tr("stat_streak")+'</div>'+
+      '</div>'+
+      '<div class="stats-card">'+
+        '<div class="stats-num sessions">'+(stats.sessions_total||0)+'</div>'+
+        '<div class="stats-label">'+tr("stat_sessions")+'</div>'+
+      '</div>'+
+      '<div class="stats-card">'+
+        '<div class="stats-num gain">'+((stats.total_proficiency_gain||0)>=0?"+":"")+(stats.total_proficiency_gain||0)+'</div>'+
+        '<div class="stats-label">'+tr("stat_total_gain")+'</div>'+
+      '</div>';
+    statsGrid.style.display = "grid";
+  }
+
   // Proficiency chips
   const grid = document.getElementById("profGrid");
   grid.innerHTML = "";
@@ -339,6 +400,33 @@ function showWelcome(profile){
       chip.className = "prof-chip";
       chip.textContent = label + " " + Math.round(score);
       grid.appendChild(chip);
+    }
+  }
+
+  // Per-topic trend sparklines (#8): last 5 session deltas per topic
+  const trendList = document.getElementById("trendList");
+  if(trendList){
+    trendList.innerHTML = "";
+    const trend = stats.topic_trend || {};
+    const entries = Object.entries(trend);
+    if(entries.length > 0){
+      const maxAbs = entries.reduce((m,[_,arr]) => Math.max(m, ...arr.map(Math.abs)), 1);
+      entries.forEach(([topic, deltas])=>{
+        const label = TOPIC_TX[topic] || topic;
+        const sum = deltas.reduce((a,b)=>a+b, 0);
+        const row = document.createElement("div");
+        row.className = "trend-row";
+        let spark = '<div class="trend-spark">';
+        deltas.forEach(d=>{
+          const cls = d > 0 ? "pos" : (d < 0 ? "neg" : "");
+          const h = Math.max(2, Math.round(Math.abs(d) / maxAbs * 20));
+          spark += '<div class="trend-bar '+cls+'" style="height:'+h+'px"></div>';
+        });
+        spark += '</div>';
+        row.innerHTML = '<div class="trend-topic">'+label+'</div>'+spark+
+          '<div class="trend-sum">'+(sum>=0?"+":"")+sum.toFixed(1)+'</div>';
+        trendList.appendChild(row);
+      });
     }
   }
 


### PR DESCRIPTION
## 概要 / Summary
\`/learn\` の Welcome Back セクションに、生徒向けの簡易ダッシュボードを追加。

## 追加された要素
1. **3-card stats row**: 連続日数 / セッション数 / 累計の伸び
2. **単元別 trend sparkline**: 各単元の直近5セッションの delta を小さな bar chart で表示（プラスは緑、マイナスは赤）、右端に合計delta

## 背景 / Why
既存の "YOUR PROGRESS" は単元別の現在値チップだけで、以下が見えなかった:
- 自分が連続で学習しているか（習慣化のモチベーション源）
- これまでの累計の成長感
- 単元ごとにどう伸びているか（スランプ or 右肩上がり）

## 変更 / Changes

### Backend — \`training_field/web/app.py\`
- 新しい内部関数 \`_compute_student_stats(history)\` を追加
- \`/api/student/{id}\` のレスポンスに \`stats\` フィールドを含める
  - \`streak_days\`: 直近の日付から、前日が無ければ止まる
  - \`sessions_total\`: ExperimentRegistry から数える
  - \`total_proficiency_gain\`: 累計 delta
  - \`topic_trend\`: 各 topic の直近5セッションの delta 配列
  - \`last_session_at\`: タイムスタンプ
- 永続化スキーマは変更なし（履歴から毎回計算）

### Frontend — \`training_field/web/templates/learn.html\`
- 3-card stats grid + trend sparkline のUIブロック
- CSS（stats-grid / stats-card / trend-row / trend-spark / trend-bar）
- i18n for ja/en

## 設計メモ
- **streak の条件**: 最後のセッションが今日または昨日のときのみカウント。1週間空けたら streak=0
- **trend 最大5件**: UIの可読性のため。古い履歴は切り捨て
- **accumulated gain ≠ 現在の proficiency**: これは「伸びの歴史」。今の到達度は既存の chip で別表示

## 検証 / Testing
- [x] py_compile
- [x] テンプレート構文OK
- [x] 初回ユーザー（sessions=0）で stats-grid が display:none のまま
- [x] trend_list は entries 0 の場合に空のまま（empty state）
- [ ] Live: 既存ユーザーのプロフィールで stats が正しく表示されるか（deploy 後）
- [ ] Live: 複数 topic 履歴で sparkline が正しく色分けされるか

## 関連 / Related
Closes #8
- 既存 \`prof-chip\` グリッドの拡張、置き換えではない
- #10（教師選択ガイド）の視覚化参考になる