### PR TITLE
[legal] Draft skeleton for /terms and /privacy (fixes #7)

### DIFF
--- a/training_field/web/app.py
+++ b/training_field/web/app.py
@@ -956,6 +956,26 @@ async def learn_session_page(request: Request):
         "topic_tx_en": TOPIC_TX_EN,
     })
 
+
+# ── Legal pages (#7) ──────────────────────────────────────────
+# Privacy / terms-of-service skeletons. Japanese is authoritative;
+# English is a convenience summary. Marked as draft pending legal review.
+LEGAL_CONTACT_EMAIL = os.environ.get("TOY_ALCHEMY_CONTACT_EMAIL", "")
+
+
+@app.get("/privacy", response_class=HTMLResponse)
+async def privacy_page(request: Request):
+    return templates.TemplateResponse(request, "legal/privacy.html", {
+        "contact_email": LEGAL_CONTACT_EMAIL,
+    })
+
+
+@app.get("/terms", response_class=HTMLResponse)
+async def terms_page(request: Request):
+    return templates.TemplateResponse(request, "legal/terms.html", {
+        "contact_email": LEGAL_CONTACT_EMAIL,
+    })
+
 @app.get("/", response_class=HTMLResponse)
 async def dashboard(request: Request):
     reg = ExperimentRegistry()

--- a/training_field/web/templates/dashboard.html
+++ b/training_field/web/templates/dashboard.html
@@ -602,5 +602,11 @@ function escapeHtml(s){
 
 renderTeacherCards();
 </script>
+
+<footer style="max-width:1200px;margin:40px auto 20px;padding:0 20px;text-align:center;font-size:11px;color:var(--muted,#86868b);letter-spacing:0.02em">
+  <a href="/terms" style="color:inherit;text-decoration:none;margin:0 6px">Terms</a>·
+  <a href="/privacy" style="color:inherit;text-decoration:none;margin:0 6px">Privacy</a>·
+  <a href="https://github.com/rojoma/toy-alchemy" target="_blank" rel="noopener" style="color:inherit;text-decoration:none;margin:0 6px">GitHub</a>
+</footer>
 </body>
 </html>

--- a/training_field/web/templates/learn.html
+++ b/training_field/web/templates/learn.html
@@ -530,5 +530,11 @@ function resetProfile(){
   location.reload();
 }
 </script>
+
+<footer style="max-width:480px;margin:24px auto 0;text-align:center;font-size:11px;color:var(--muted);letter-spacing:0.02em">
+  <a href="/terms" style="color:var(--muted);text-decoration:none;margin:0 6px">利用規約</a>·
+  <a href="/privacy" style="color:var(--muted);text-decoration:none;margin:0 6px">プライバシー</a>·
+  <a href="https://github.com/rojoma/toy-alchemy" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none;margin:0 6px">GitHub</a>
+</footer>
 </body>
 </html>

--- a/training_field/web/templates/legal/base.html
+++ b/training_field/web/templates/legal/base.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>{{ page_title }} — Toy Alchemy</title>
+<style>
+:root{
+  --bg:#fafaf7;--surface:#ffffff;--surface-2:#f4f4f0;
+  --border:rgba(0,0,0,0.06);--border-strong:rgba(0,0,0,0.12);
+  --text:#1d1d1f;--text-secondary:#424245;--muted:#86868b;
+  --link:#0071e3;--danger:#c1272d;--warning:#f59e0b;--success:#1f8a4c;
+  --radius:12px;--radius-pill:20px;
+  --ease:cubic-bezier(0.22,1,0.36,1);
+  font-family:-apple-system,BlinkMacSystemFont,"Hiragino Kaku Gothic ProN",sans-serif;
+}
+:root[data-theme="dark"]{
+  --bg:#0a0a0a;--surface:#161618;--surface-2:#1f1f22;
+  --border:rgba(255,255,255,0.08);--border-strong:rgba(255,255,255,0.16);
+  --text:#f5f5f7;--text-secondary:#c7c7cc;--muted:#86868b;
+}
+*{box-sizing:border-box}
+body{
+  margin:0;padding:32px 20px;
+  background:var(--bg);color:var(--text);
+  line-height:1.7;font-size:15px;
+}
+.legal-wrap{max-width:760px;margin:0 auto}
+.back-link{
+  display:inline-block;color:var(--muted);text-decoration:none;
+  font-size:13px;margin-bottom:24px;
+}
+.back-link:hover{color:var(--text)}
+h1{font-size:28px;letter-spacing:-0.02em;margin:0 0 8px}
+h2{font-size:18px;letter-spacing:-0.01em;margin-top:32px;padding-top:20px;border-top:1px solid var(--border)}
+h2:first-of-type{border-top:none;padding-top:0}
+h3{font-size:15px;color:var(--text-secondary);margin-top:18px}
+p,ul{margin:10px 0}
+ul{padding-left:22px}
+li{margin:4px 0}
+a{color:var(--link)}
+a:hover{text-decoration:underline}
+hr{border:none;border-top:1px solid var(--border);margin:40px 0}
+.last-updated{color:var(--muted);font-size:13px;margin:0 0 24px}
+.legal-banner{
+  background:rgba(245,158,11,0.12);
+  border:1px solid rgba(245,158,11,0.35);
+  color:var(--warning);
+  padding:12px 16px;border-radius:var(--radius);
+  font-size:13px;margin-bottom:24px;
+}
+.legal-banner strong{color:var(--warning)}
+em{color:var(--muted)}
+</style>
+</head>
+<body>
+<script>(function(){var t=localStorage.getItem("tfTheme")||"light";document.documentElement.setAttribute("data-theme",t);})();</script>
+<div class="legal-wrap">
+  <a href="/" class="back-link">← Toy Alchemy</a>
+  {% block content %}{% endblock %}
+  <hr />
+  <p style="font-size:12px;color:var(--muted)">
+    <a href="/terms">利用規約 / Terms</a> ·
+    <a href="/privacy">プライバシーポリシー / Privacy</a> ·
+    <a href="https://github.com/rojoma/toy-alchemy" target="_blank" rel="noopener">GitHub</a>
+  </p>
+</div>
+</body>
+</html>

--- a/training_field/web/templates/legal/privacy.html
+++ b/training_field/web/templates/legal/privacy.html
@@ -1,0 +1,113 @@
+{% extends "legal/base.html" %}
+{% set page_title = "プライバシーポリシー / Privacy Policy" %}
+{% block content %}
+
+<div class="legal-banner">
+  <strong>⚠ ドラフト / Draft status.</strong>
+  本書はエンジニアによる初稿であり、法律家のレビューを受けていません。公開前に弁護士または教育法務の専門家による確認が必要です。内容の最終責任は Toy Alchemy プロジェクト運営者にあります。
+</div>
+
+<h1>プライバシーポリシー</h1>
+<p class="last-updated">最終更新: 2026-04-23（ドラフト v0.1）</p>
+
+<p>Toy Alchemy（以下「本サービス」）は、利用者の個人情報を以下の方針に基づき取り扱います。本サービスは学習目的のAI家庭教師プラットフォームであり、未成年の利用を想定しているため、特に慎重な取り扱いを心がけます。</p>
+
+<h2>1. 運営者</h2>
+<p>MIT MAS.664 AI Studio Spring 2026 — Team Toy Alchemy（{{ contact_email or "TBD: 運営代表メールアドレスを記載" }}）</p>
+
+<h2>2. 収集する情報</h2>
+
+<h3>2.1 生徒が直接入力する情報</h3>
+<ul>
+  <li>名前またはニックネーム（生徒が自由に設定）</li>
+  <li>学年（小1〜高3）</li>
+  <li>教科（算数／国語／理科／社会／英語）</li>
+  <li>学習したい単元・学習範囲（自由記述）</li>
+  <li>セッション中の発言（先生への質問、回答など）</li>
+  <li>セッション終了後の任意フィードバック（5段階評価、タグ、自由記述）</li>
+  <li>ターンごとの任意フィードバック（👍／❓／👎）</li>
+</ul>
+
+<h3>2.2 利用に伴い自動生成される情報</h3>
+<ul>
+  <li>セッションID（ランダム生成）</li>
+  <li>習熟度スコア（単元ごとに算出）</li>
+  <li>AI評価指標（ZPD整合性、Bloom レベル、説明の明瞭度など）</li>
+  <li>セッション履歴のタイムスタンプ</li>
+  <li>教師側の記憶（Teacher Memory：生徒ごとの観察メモ）</li>
+</ul>
+
+<h3>2.3 ブラウザに保存される情報（LocalStorage）</h3>
+<ul>
+  <li>生徒ID（匿名ID）</li>
+  <li>選択中の教師ID</li>
+  <li>言語設定（ja / en）</li>
+  <li>テーマ設定（light / dark）</li>
+</ul>
+<p>これらは利用者のブラウザに保存され、サーバーには送信されない場合があります。ブラウザの設定で削除可能です。</p>
+
+<h2>3. 利用目的</h2>
+<ul>
+  <li>AIによる個別最適化された学習指導の提供</li>
+  <li>生徒の学習進捗の可視化</li>
+  <li>教師AIの教え方の改善（品質向上のための集計・分析）</li>
+  <li>研究成果の発表（MIT MAS.664 AI Studio 授業および学術的な発表。公表時は個人を特定できない形に加工します）</li>
+  <li>サービス運営上のバグ調査・品質改善</li>
+</ul>
+
+<h2>4. 第三者提供</h2>
+<p>以下の外部サービス（データ処理業務委託先）に、サービス運営上必要な範囲で情報を提供します。</p>
+<ul>
+  <li><strong>OpenAI</strong>（米国）：セッション中の対話テキストをAIモデルの推論のために送信します。OpenAIは同データをモデル学習には使用しない契約（API利用）で運用しています。</li>
+  <li><strong>Railway</strong>（米国）：本サービスのホスティングおよびデータ永続化を提供します。</li>
+</ul>
+<p>上記以外の第三者に個人情報を提供することはありません（法令に基づく開示請求を除く）。</p>
+
+<h2>5. 国外への移転</h2>
+<p>前項の通り、データは米国所在のサービスに送信・保存されます。利用者はこの国外移転に同意の上、本サービスを利用するものとします。</p>
+
+<h2>6. 保存期間</h2>
+<p>以下のデータは、削除依頼を受けるまで保存します。</p>
+<ul>
+  <li>生徒プロフィール</li>
+  <li>セッション履歴・評価レポート</li>
+  <li>フィードバック記録</li>
+</ul>
+<p>TBD: 具体的な保存期間（例: 1年、卒業まで）を運営方針で決定する必要があります。</p>
+
+<h2>7. 削除・開示請求</h2>
+<p>生徒本人または保護者は、以下の請求ができます。</p>
+<ul>
+  <li>登録されている情報の開示請求</li>
+  <li>情報の訂正・削除請求</li>
+  <li>サービス利用停止の請求</li>
+</ul>
+<p>請求は {{ contact_email or "TBD: 運営代表メールアドレス" }} にご連絡ください。本人確認の後、合理的な期間内に対応します。</p>
+
+<h2>8. 未成年の利用と保護者の同意</h2>
+<p>本サービスは未成年（18歳未満）の利用を想定しています。</p>
+<p>TBD: 保護者同意フローの実装時期と方式（同意画面、メール確認、書面など）を決定する必要があります。現状のドラフトでは、「保護者の同意を得た上で利用してください」という告知にとどまっています。</p>
+
+<h2>9. セキュリティ</h2>
+<ul>
+  <li>APIキーなどの認証情報は環境変数で管理し、リポジトリにコミットしません。</li>
+  <li>通信はHTTPSで暗号化しています（Railway標準）。</li>
+  <li>データベースへのアクセスは、運営者および本サービスのプロセスに限定しています。</li>
+</ul>
+
+<h2>10. クッキー等</h2>
+<p>本サービスは認証セッションを保持するためにCookieまたはLocalStorageを使用します。利用者はブラウザ設定で無効化できますが、その場合一部機能が利用できなくなります。</p>
+
+<h2>11. 本ポリシーの変更</h2>
+<p>本ポリシーは、法令改正やサービス内容の変更に応じて改訂することがあります。重要な変更がある場合は本ページで告知します。</p>
+
+<h2>12. お問い合わせ</h2>
+<p>{{ contact_email or "TBD: 運営代表メールアドレスを記載" }}</p>
+
+<hr />
+
+<h2 id="english">English (summary)</h2>
+<p><em>This English summary is for convenience only. The Japanese version above is authoritative.</em></p>
+<p>Toy Alchemy is an AI tutoring platform built for MIT MAS.664 AI Studio, Spring 2026. Data we collect includes: student nickname, grade/subject, session dialogue with the AI tutor, proficiency scores, and optional feedback. Data is sent to OpenAI (AI inference) and stored on Railway (US hosting). Data is not sold or shared beyond these service providers. Users may request disclosure, correction, or deletion of their data by emailing us. This service is intended for minors; parental consent is expected. This is a <strong>draft document pending legal review</strong>.</p>
+
+{% endblock %}

--- a/training_field/web/templates/legal/terms.html
+++ b/training_field/web/templates/legal/terms.html
@@ -1,0 +1,85 @@
+{% extends "legal/base.html" %}
+{% set page_title = "利用規約 / Terms of Service" %}
+{% block content %}
+
+<div class="legal-banner">
+  <strong>⚠ ドラフト / Draft status.</strong>
+  本書はエンジニアによる初稿であり、法律家のレビューを受けていません。公開前に弁護士または教育法務の専門家による確認が必要です。
+</div>
+
+<h1>利用規約</h1>
+<p class="last-updated">最終更新: 2026-04-23（ドラフト v0.1）</p>
+
+<h2>1. 目的</h2>
+<p>本規約は、Toy Alchemy（以下「本サービス」）の利用条件を定めるものです。利用者は本サービスを利用することにより、本規約に同意したものとみなされます。</p>
+
+<h2>2. 運営者</h2>
+<p>MIT MAS.664 AI Studio Spring 2026 — Team Toy Alchemy（{{ contact_email or "TBD: 運営代表メールアドレスを記載" }}）</p>
+
+<h2>3. 本サービスの内容</h2>
+<p>本サービスは、AIエージェントが家庭教師役として、主に算数科目を中心とした学習指導をオンラインで提供するものです。本サービスは教育研究プロジェクトの一環であり、学校教育を代替するものではありません。</p>
+
+<h2>4. 対象年齢と保護者の同意</h2>
+<p>本サービスは未成年の利用を想定していますが、18歳未満の利用者は保護者の同意を得た上で利用してください。</p>
+<p>TBD: 保護者同意フロー（同意画面、同意確認メール、書面など）の実装時期・方式を運営方針で決定する必要があります。</p>
+
+<h2>5. 利用料金</h2>
+<p>現時点では本サービスは無償で提供されています。将来的に有償化する場合は、事前に利用者へ告知します。</p>
+
+<h2>6. AIによる指導の性質</h2>
+<p>本サービスはAI（大規模言語モデル）による自動応答で指導を行います。以下の点について、利用者は予め了承のうえご利用ください。</p>
+<ul>
+  <li>AIの回答には誤りや不適切な内容が含まれる可能性があります。</li>
+  <li>学校の授業や教科書の内容と完全に一致するとは限りません。</li>
+  <li>重要な学習判断は保護者・学校教員の確認の上で行ってください。</li>
+  <li>本サービスで得られた学習成果は、学校の成績や資格を保証するものではありません。</li>
+</ul>
+
+<h2>7. 利用者の責任</h2>
+<p>利用者は以下の事項を遵守してください。</p>
+<ul>
+  <li>他の利用者や運営者を誹謗中傷する発言を入力しない。</li>
+  <li>第三者の個人情報・著作権を侵害する情報を送信しない。</li>
+  <li>本サービスを商用目的で再配布しない（本リポジトリ自体のMITライセンスは別途適用）。</li>
+  <li>本サービスを不正アクセス・過度な負荷をかける目的で利用しない。</li>
+</ul>
+
+<h2>8. 禁止事項</h2>
+<p>以下の行為は禁止します。</p>
+<ul>
+  <li>本サービスの運営を妨害する行為</li>
+  <li>他の利用者のデータの不正取得</li>
+  <li>法令または公序良俗に反する行為</li>
+  <li>本サービスをリバースエンジニアリングして脆弱性を悪用する行為（責任ある脆弱性報告は歓迎します）</li>
+</ul>
+
+<h2>9. 知的財産</h2>
+<p>本サービスのソースコードは<a href="https://github.com/rojoma/toy-alchemy" target="_blank" rel="noopener">GitHub</a>で公開されています。AI生成コンテンツ（AI教師の発言）に関する権利は、各生成時点での生成AIサービスの利用規約に準じます。</p>
+
+<h2>10. 免責事項</h2>
+<ul>
+  <li>本サービスはAI研究・教育目的で提供されており、商用レベルの SLA は保証しません。</li>
+  <li>本サービスの利用により生じたいかなる損害（直接・間接を問わず）についても、運営者は責任を負いません。</li>
+  <li>本サービスは予告なく停止・変更される場合があります。</li>
+</ul>
+
+<h2>11. データの取り扱い</h2>
+<p>利用者データの取り扱いは<a href="/privacy">プライバシーポリシー</a>に従います。</p>
+
+<h2>12. 規約の変更</h2>
+<p>本規約は、必要に応じて改訂することがあります。重要な変更がある場合は本ページで告知します。</p>
+
+<h2>13. 準拠法・管轄</h2>
+<p>本規約は日本法に準拠するものとし、本サービスに関する紛争は東京地方裁判所を第一審の専属的合意管轄とします。</p>
+<p>TBD: 米国での利用も視野に入れる場合は、管轄条項の再検討が必要です（#7 決定メモ参照）。</p>
+
+<h2>14. お問い合わせ</h2>
+<p>{{ contact_email or "TBD: 運営代表メールアドレスを記載" }}</p>
+
+<hr />
+
+<h2 id="english">English (summary)</h2>
+<p><em>This English summary is for convenience only. The Japanese version above is authoritative.</em></p>
+<p>Toy Alchemy is an AI tutoring service for educational research. The service is free, may contain errors typical of AI-generated content, and is not a substitute for formal education. Users under 18 should use with parental consent. Governing law: Japan. Data handling follows our <a href="/privacy">Privacy Policy</a>. This is a <strong>draft document pending legal review</strong>.</p>
+
+{% endblock %}


### PR DESCRIPTION
## 概要 / Summary
\`/terms\` と \`/privacy\` のスケルトンページ追加。対象法域は **Japan のみで v1**、文言は **ドラフト — 法律家レビュー前**として明示。

## なぜ / Why
- #29（生徒フィードバック）、#44（ダッシュボード）、#45（curriculum 外出し）まで進んで、公開への技術的障害は #7 のみになった
- #31（LP）や #32（写真アップ）は #7 の存在が前提
- \`docs/open-issues-decisions.md\` の #7 分析で「日本のみで始める」が最小の decision と結論

## 変更 / Changes

### 新規テンプレート
- \`training_field/web/templates/legal/base.html\` — 既存テーマと統一した最小のレイアウト
- \`training_field/web/templates/legal/privacy.html\` — **ドラフト** プライバシーポリシー
- \`training_field/web/templates/legal/terms.html\` — **ドラフト** 利用規約

### FastAPI ルート
- \`GET /privacy\` / \`GET /terms\` — \`LEGAL_CONTACT_EMAIL\` 環境変数（\`TOY_ALCHEMY_CONTACT_EMAIL\`）を任意で注入可能

### フッター追加
- \`/learn\`（学生入口）
- \`/\`（ダッシュボード）

## Privacy 文書が列挙しているデータ項目（実装と突き合わせ済み）
| 源 | 中身 |
|---|---|
| 生徒入力 | 名前（ニックネーム可）/ 学年 / 教科 / 学習範囲（自由記述）/ セッション中の発言 / #29 フィードバック |
| 自動生成 | セッションID / 習熟度 / AI評価指標 / Teacher Memory |
| LocalStorage | 生徒ID / 教師ID / 言語 / テーマ |
| 第三者送信 | OpenAI（推論）/ Railway（ホスティング） |

## ドラフトに残した TBD（人間判断が必要）
- 運営代表の連絡先メールアドレス（env var で差し込み可能、当面空欄 or "TBD"）
- 保護者同意フローの実装時期・方式
- データ保存期間（具体的な年数）
- US 展開する場合の COPPA / 管轄の追記

## 検証 / Testing
- [x] py_compile
- [x] \`TestClient\` で \`/privacy\` と \`/terms\` が 200 返却、ドラフトバナーが描画されることを確認
- [x] footer リンクで行き来できる
- [ ] 法律家レビュー（**本PRマージ後、別途依頼**）

## スコープ外（明示的に未着手）/ Out of Scope
- 保護者同意ダイアログ / モーダル — #7 スコープから分離、別 issue で対応
- US 向け文面 / COPPA 対応 — 法域決定が Japan-only なので不要
- メール通知基盤 — 削除請求は手動運用で十分な初期段階

## 関連 / Related
Closes #7
- #31（LP 公開前に required）のブロッカー解消
- #32（写真アップロード）の前提（画像データに関する記載は将来 privacy.html に追記）
- \`docs/open-issues-decisions.md\` 内の #7 セクションを参照