### PR TITLE
[Feature] Landing page at / (fixes #31)

### DIFF
--- a/training_field/web/app.py
+++ b/training_field/web/app.py
@@ -977,7 +977,14 @@ async def terms_page(request: Request):
     })
 
 @app.get("/", response_class=HTMLResponse)
-async def dashboard(request: Request):
+async def landing(request: Request):
+    """Public-facing landing page (#31). Draft copy; audience/CTA are placeholder."""
+    return templates.TemplateResponse(request, "landing.html", {})
+
+
+@app.get("/observatory", response_class=HTMLResponse)
+async def observatory(request: Request):
+    """Legacy dashboard (previously at /). Agent-vs-agent + experiment overview."""
     reg = ExperimentRegistry()
     summary = reg.summary()
     student_data = []

--- a/training_field/web/templates/history.html
+++ b/training_field/web/templates/history.html
@@ -235,7 +235,7 @@ main{max-width:1280px;margin:0 auto;padding:64px 40px 120px}
 <header class="header">
   <div class="header-inner">
     <div class="brand">Training Field<span class="brand-mark"> / History</span></div>
-    <a href="/" class="icon-btn">← Dashboard</a>
+    <a href="/observatory" class="icon-btn">← Dashboard</a>
   </div>
 </header>
 

--- a/training_field/web/templates/landing.html
+++ b/training_field/web/templates/landing.html
@@ -1,0 +1,345 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Toy Alchemy — お子さまに寄り添うAI家庭教師</title>
+<meta name="description" content="AI家庭教師が、お子さまの理解度とペースに合わせて教え方を変えます。MIT MAS.664 AI Studioの研究プロジェクト。" />
+<style>
+:root{
+  --bg:#fafaf7;--surface:#ffffff;--surface-2:#f4f4f0;
+  --border:rgba(0,0,0,0.06);--border-strong:rgba(0,0,0,0.12);
+  --text:#1d1d1f;--text-secondary:#424245;--muted:#86868b;
+  --link:#0071e3;--warning:#f59e0b;--success:#1f8a4c;
+  --radius:14px;--radius-lg:22px;--radius-pill:980px;
+  --ease:cubic-bezier(0.22,1,0.36,1);
+  font-family:-apple-system,BlinkMacSystemFont,"Hiragino Kaku Gothic ProN",sans-serif;
+}
+:root[data-theme="dark"]{
+  --bg:#0a0a0a;--surface:#161618;--surface-2:#1f1f22;
+  --border:rgba(255,255,255,0.08);--border-strong:rgba(255,255,255,0.16);
+  --text:#f5f5f7;--text-secondary:#c7c7cc;--muted:#86868b;
+}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+html,body{background:var(--bg);color:var(--text);line-height:1.7;font-size:16px}
+
+/* ── Top nav ──────────────────────────────────── */
+.nav{
+  position:sticky;top:0;z-index:10;
+  background:rgba(250,250,247,0.72);backdrop-filter:saturate(180%) blur(20px);
+  -webkit-backdrop-filter:saturate(180%) blur(20px);
+  border-bottom:1px solid var(--border);
+  padding:14px 24px;display:flex;align-items:center;justify-content:space-between;
+}
+:root[data-theme="dark"] .nav{background:rgba(10,10,10,0.75)}
+.brand{font-weight:600;font-size:17px;letter-spacing:-0.01em;color:var(--text);text-decoration:none}
+.brand::before{content:"🧪";margin-right:6px}
+.nav-right{display:flex;gap:20px;align-items:center}
+.nav-link{color:var(--text-secondary);text-decoration:none;font-size:14px}
+.nav-link:hover{color:var(--text)}
+.nav-cta{
+  background:var(--text);color:var(--bg);padding:8px 18px;
+  border-radius:var(--radius-pill);font-size:14px;font-weight:500;
+  text-decoration:none;transition:opacity 0.15s var(--ease);
+}
+.nav-cta:hover{opacity:0.82}
+
+/* ── Hero ──────────────────────────────────── */
+.hero{
+  max-width:820px;margin:0 auto;padding:80px 24px 60px;
+  text-align:center;
+}
+.kicker{
+  display:inline-block;font-size:12px;font-weight:500;
+  padding:6px 14px;border-radius:var(--radius-pill);
+  background:var(--surface-2);color:var(--text-secondary);
+  letter-spacing:0.02em;margin-bottom:24px;
+}
+.hero h1{
+  font-size:clamp(32px, 6vw, 56px);
+  letter-spacing:-0.025em;line-height:1.15;
+  font-weight:600;margin-bottom:18px;
+}
+.hero-sub{
+  font-size:clamp(16px, 2.5vw, 19px);
+  color:var(--text-secondary);max-width:620px;margin:0 auto 36px;
+}
+.hero-cta-row{display:flex;gap:12px;justify-content:center;flex-wrap:wrap}
+.btn-primary{
+  background:var(--text);color:var(--bg);padding:14px 28px;
+  border-radius:var(--radius-pill);font-size:15px;font-weight:500;
+  text-decoration:none;transition:opacity 0.15s var(--ease);
+  border:none;cursor:pointer;font-family:inherit;
+}
+.btn-primary:hover{opacity:0.85}
+.btn-secondary{
+  background:transparent;color:var(--text);padding:14px 28px;
+  border-radius:var(--radius-pill);font-size:15px;font-weight:500;
+  text-decoration:none;border:1px solid var(--border-strong);
+  transition:background 0.15s var(--ease);
+}
+.btn-secondary:hover{background:var(--surface-2)}
+.hero-note{
+  font-size:12px;color:var(--muted);margin-top:20px;
+}
+
+/* ── Section ──────────────────────────────────── */
+.section{max-width:980px;margin:0 auto;padding:60px 24px}
+.section h2{
+  font-size:clamp(24px, 4vw, 34px);
+  letter-spacing:-0.02em;font-weight:600;
+  margin-bottom:40px;text-align:center;
+}
+.section-intro{
+  font-size:16px;color:var(--text-secondary);
+  max-width:620px;margin:-30px auto 40px;text-align:center;
+}
+
+/* ── Feature grid ──────────────────────────────────── */
+.features{
+  display:grid;grid-template-columns:repeat(auto-fit, minmax(260px, 1fr));
+  gap:20px;
+}
+.feature-card{
+  background:var(--surface);border:1px solid var(--border);
+  border-radius:var(--radius);padding:24px;
+}
+.feature-icon{font-size:24px;margin-bottom:12px;display:block}
+.feature-title{
+  font-size:16px;font-weight:600;letter-spacing:-0.01em;
+  margin-bottom:6px;
+}
+.feature-desc{font-size:14px;color:var(--text-secondary);line-height:1.65}
+
+/* ── How it works ──────────────────────────────────── */
+.steps{display:grid;grid-template-columns:repeat(auto-fit, minmax(240px, 1fr));gap:24px}
+.step{position:relative;padding:20px 0 0 48px}
+.step-num{
+  position:absolute;left:0;top:0;
+  width:36px;height:36px;border-radius:50%;
+  background:var(--text);color:var(--bg);
+  display:flex;align-items:center;justify-content:center;
+  font-size:15px;font-weight:600;
+}
+.step-title{font-size:15px;font-weight:600;margin-bottom:4px}
+.step-desc{font-size:13px;color:var(--text-secondary)}
+
+/* ── FAQ ──────────────────────────────────── */
+.faq{max-width:720px;margin:0 auto}
+.faq-item{
+  border-bottom:1px solid var(--border);
+  padding:18px 0;
+}
+.faq-item summary{
+  cursor:pointer;font-size:15px;font-weight:500;
+  list-style:none;display:flex;align-items:center;justify-content:space-between;
+}
+.faq-item summary::-webkit-details-marker{display:none}
+.faq-item summary::after{content:"+";font-size:20px;color:var(--muted);font-weight:300}
+.faq-item[open] summary::after{content:"−"}
+.faq-body{padding-top:14px;color:var(--text-secondary);font-size:14px;line-height:1.7}
+
+/* ── Trust ribbon ──────────────────────────────────── */
+.trust{
+  background:var(--surface-2);padding:32px 24px;text-align:center;
+  border-radius:var(--radius);margin:40px auto;max-width:700px;
+}
+.trust-title{font-size:13px;font-weight:500;color:var(--muted);letter-spacing:0.05em;margin-bottom:12px;text-transform:uppercase}
+.trust-meta{font-size:15px;color:var(--text-secondary);line-height:1.8}
+
+/* ── Footer ──────────────────────────────────── */
+.footer{
+  border-top:1px solid var(--border);padding:30px 24px 40px;
+  text-align:center;color:var(--muted);font-size:12px;letter-spacing:0.02em;
+  margin-top:60px;
+}
+.footer a{color:var(--muted);text-decoration:none;margin:0 8px}
+.footer a:hover{color:var(--text)}
+
+@media (max-width: 600px){
+  .hero{padding:50px 20px 40px}
+  .section{padding:40px 20px}
+}
+</style>
+</head>
+<body>
+<script>(function(){var t=localStorage.getItem("tfTheme")||"light";document.documentElement.setAttribute("data-theme",t);})();</script>
+
+<!-- Top nav -->
+<nav class="nav">
+  <a href="/" class="brand">Toy Alchemy</a>
+  <div class="nav-right">
+    <a href="/observatory" class="nav-link">Observatory</a>
+    <a href="https://github.com/rojoma/toy-alchemy" target="_blank" rel="noopener" class="nav-link">GitHub</a>
+    <a href="/learn" class="nav-cta">試してみる</a>
+  </div>
+</nav>
+
+<!-- Hero -->
+<section class="hero">
+  <div class="kicker">MIT MAS.664 AI Studio — Spring 2026</div>
+  <h1>お子さまに寄り添う、<br/>学び方を学ぶAI家庭教師</h1>
+  <p class="hero-sub">
+    同じ単元でも、お子さまによって「つまずくところ」は違います。
+    Toy Alchemyは、会話の一問一答から理解度を読み取り、
+    教え方を調整する研究プロジェクト。
+  </p>
+  <div class="hero-cta-row">
+    <a href="/learn" class="btn-primary">無料で試してみる →</a>
+    <a href="/observatory" class="btn-secondary">技術的な中身を見る</a>
+  </div>
+  <p class="hero-note">登録不要で体験できます · MIT発の教育研究プロジェクト</p>
+</section>
+
+<!-- What it does -->
+<section class="section">
+  <h2>他のAI家庭教師と、何が違うの？</h2>
+  <p class="section-intro">
+    答えを教えるだけなら、どんなAIチャットでもできます。
+    私たちが目指すのは、生徒の「考え方」そのものに寄り添う先生です。
+  </p>
+
+  <div class="features">
+    <div class="feature-card">
+      <span class="feature-icon">🧭</span>
+      <div class="feature-title">4つのキャラクターから選べる</div>
+      <p class="feature-desc">
+        Warm Coach、Prof. Tanaka、Ms. Rivera、Cool Mentor。
+        温かさや厳しさ、ペースの違う先生の中から、お子さまに合うタイプを選べます。
+      </p>
+    </div>
+    <div class="feature-card">
+      <span class="feature-icon">📝</span>
+      <div class="feature-title">宿題の範囲をそのまま相談できる</div>
+      <p class="feature-desc">
+        「教科書 p.42 の例題」「分数の割り算だけ」など、
+        学校の宿題に合わせて学習範囲を直接指定できます。
+      </p>
+    </div>
+    <div class="feature-card">
+      <span class="feature-icon">📊</span>
+      <div class="feature-title">学んだ記録が残る</div>
+      <p class="feature-desc">
+        単元ごとの習熟度や、何日連続で学んだかをダッシュボードで確認。
+        お子さまの成長を見守れます。
+      </p>
+    </div>
+    <div class="feature-card">
+      <span class="feature-icon">👀</span>
+      <div class="feature-title">AIの教え方を別のAIがチェック</div>
+      <p class="feature-desc">
+        Principal Agent（審判役）が毎回の会話を見守り、
+        教え方の質を6つの観点でスコアリングします。
+      </p>
+    </div>
+    <div class="feature-card">
+      <span class="feature-icon">💬</span>
+      <div class="feature-title">セッション後にフィードバック</div>
+      <p class="feature-desc">
+        生徒自身が「今日の先生はどうだったか」を教えてくれます。
+        そのシグナルで、AIはさらに学んでいきます。
+      </p>
+    </div>
+    <div class="feature-card">
+      <span class="feature-icon">🔬</span>
+      <div class="feature-title">オープンソースの研究プロジェクト</div>
+      <p class="feature-desc">
+        MIT MAS.664 AI Studio の研究として公開中。
+        コードは <a href="https://github.com/rojoma/toy-alchemy" target="_blank" rel="noopener">GitHub</a> で誰でも見られます。
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- How it works -->
+<section class="section">
+  <h2>どうやって使うの？</h2>
+  <div class="steps">
+    <div class="step">
+      <div class="step-num">1</div>
+      <div class="step-title">名前と学年を入力</div>
+      <div class="step-desc">簡単なプロフィール登録だけ。お子さまの学年と教科を選びます。</div>
+    </div>
+    <div class="step">
+      <div class="step-num">2</div>
+      <div class="step-title">先生と単元を選ぶ</div>
+      <div class="step-desc">4人の先生から1人を選び、学びたい単元を指定。宿題の範囲も書けます。</div>
+    </div>
+    <div class="step">
+      <div class="step-num">3</div>
+      <div class="step-title">会話で学ぶ</div>
+      <div class="step-desc">AIの先生と1対1で対話。わかったら「次へ」、わからなければ「もう一度」。</div>
+    </div>
+    <div class="step">
+      <div class="step-num">4</div>
+      <div class="step-title">ふりかえり</div>
+      <div class="step-desc">確認テストと、先生についてのフィードバックで一日を締めくくり。</div>
+    </div>
+  </div>
+</section>
+
+<!-- Trust ribbon -->
+<section class="trust">
+  <div class="trust-title">About this project</div>
+  <p class="trust-meta">
+    Toy Alchemy は MIT スローン校の MAS.664 AI Studio（2026年春期）の研究プロジェクトです。<br/>
+    現在は β 版として無償で公開しています。
+  </p>
+</section>
+
+<!-- FAQ -->
+<section class="section">
+  <h2>よくある質問</h2>
+  <div class="faq">
+    <details class="faq-item">
+      <summary>利用料はかかりますか？</summary>
+      <div class="faq-body">
+        現時点では無償です。将来的に有料化する場合は事前に告知します。
+      </div>
+    </details>
+    <details class="faq-item">
+      <summary>対象年齢は？</summary>
+      <div class="faq-body">
+        小学生から高校生までを想定しています。特に小6算数で検証を進めています。
+        未成年の利用には保護者の同意をお願いしています。詳しくは
+        <a href="/terms">利用規約</a>をご覧ください。
+      </div>
+    </details>
+    <details class="faq-item">
+      <summary>子どもの入力内容は保存されますか？</summary>
+      <div class="faq-body">
+        学習の記録や習熟度を残すために保存します。外部への販売や共有はしません。
+        データの開示・削除の請求も可能です。詳しくは
+        <a href="/privacy">プライバシーポリシー</a>を参照してください。
+      </div>
+    </details>
+    <details class="faq-item">
+      <summary>AIが間違った答えを教えることはありますか？</summary>
+      <div class="faq-body">
+        可能性はあります。Principal Agent（審判役AI）が毎回チェックしていますが、
+        完全ではありません。重要な学習判断は保護者・学校教員の確認の上で行ってください。
+      </div>
+    </details>
+    <details class="faq-item">
+      <summary>既存の学校教育の代わりになる？</summary>
+      <div class="faq-body">
+        なりません。Toy Alchemy は補助ツールです。
+        学校教育を補うための研究プロジェクトとしてご利用ください。
+      </div>
+    </details>
+  </div>
+
+  <div style="text-align:center;margin-top:40px">
+    <a href="/learn" class="btn-primary">試してみる →</a>
+  </div>
+</section>
+
+<footer class="footer">
+  <a href="/observatory">Observatory</a>·
+  <a href="/terms">利用規約</a>·
+  <a href="/privacy">プライバシー</a>·
+  <a href="https://github.com/rojoma/toy-alchemy" target="_blank" rel="noopener">GitHub</a>
+  <div style="margin-top:14px">© 2026 Toy Alchemy — MIT MAS.664 AI Studio</div>
+</footer>
+</body>
+</html>

--- a/training_field/web/templates/learn.html
+++ b/training_field/web/templates/learn.html
@@ -137,7 +137,7 @@ h1{font-size:28px;font-weight:600;letter-spacing:-0.025em;margin-bottom:8px}
 </head>
 <body>
 <script>(function(){var t=localStorage.getItem("tfTheme")||"light";document.documentElement.setAttribute("data-theme",t);})();</script>
-<a href="/" class="back-link" data-i18n="back_training">← Training Field</a>
+<a href="/observatory" class="back-link" data-i18n="back_training">← Training Field</a>
 <button class="lang-link" id="langbtn" onclick="toggleLang()">JA</button>
 
 <!-- Onboarding (shown if no saved profile) -->

--- a/training_field/web/templates/session.html
+++ b/training_field/web/templates/session.html
@@ -445,7 +445,7 @@ select:hover{border-color:var(--text)}
 <script>(function(){var t=localStorage.getItem("tfTheme")||"light";document.documentElement.setAttribute("data-theme",t);})();</script>
 
 <div class="hdr">
-  <a href="/" class="back" data-i18n="back_dashboard">← Dashboard</a>
+  <a href="/observatory" class="back" data-i18n="back_dashboard">← Dashboard</a>
   <div class="hdr-info">
     <div class="av" style="background:{{ student.color }}1a;color:{{ student.color }}">{{ student.name[:2].upper() }}</div>
     <div>


### PR DESCRIPTION
## 概要 / Summary
\`/\` を一般ユーザー向けランディングページに差し替え、既存 Observatory ダッシュボードを \`/observatory\` へ移動。

## なぜ / Why
- 決定メモ \`docs/open-issues-decisions.md\` に従い、**仮ターゲット（保護者）+ 仮CTA（"試してみる" → /learn）**で実装
- #7 がマージ済み（Terms/Privacy）なので、CTA を \`/learn\` に流す導線は法的に問題なし
- 最終コピーの決定は team judgment が必要だが、配管は全て繋がった状態で提出

## 構成 / Structure
1. **Top nav**: brand / Observatory / GitHub / CTA
2. **Hero**: MIT kicker + キャッチコピー + サブ + CTA × 2（試してみる / 技術的な中身を見る）
3. **Feature grid** (6 枚): 教師選択・宿題範囲・ダッシュボード・Principal Agent・フィードバック・OSS
4. **How it works** (4 ステップ): 登録 → 先生選択 → 会話 → ふりかえり
5. **Trust ribbon**: MIT MAS.664 AI Studio の研究プロジェクトであることを明示
6. **FAQ** (5 件): 料金 / 対象年齢 / プライバシー / AI の誤り / 学校との関係
7. **Footer**: Observatory / Terms / Privacy / GitHub

## ルート / Routes
| 旧 | 新 |
|---|---|
| \`/\` → dashboard.html | \`/\` → landing.html |
| — | \`/observatory\` → dashboard.html（従来 / と同じ内容） |

既存の back-link 3 箇所（\`/learn\`, \`/session\`, \`/history\`）も \`/observatory\` に変更。\`legal/base.html\` の "← Toy Alchemy" は \`/\` のままで OK（LP に戻る）。

## 検証 / Testing
- [x] py_compile
- [x] TestClient で \`/\`, \`/observatory\`, \`/learn\`, \`/terms\`, \`/privacy\` すべて 200
- [x] LP 内に "Toy Alchemy"、"試してみる"、\`/learn\` リンクが存在
- [x] 既存 API エンドポイントに影響なし（ルート変更は HTML ページのみ）
- [ ] Live: モバイル表示確認（deploy 後）
- [ ] Live: デモ実行からのユーザー動線確認

## スコープ外（人間判断待ち、決定メモ参照）/ Out of Scope
- **最終的なコピー・トーンの確定** — ターゲット（保護者 / 生徒本人 / 教育者 / 研究者）の優先順決定
- **ヒーロー画像 / デモ動画** — 素材作成が別タスク
- **アナリティクス / トラッキング** — 別検討
- **サインアップゲーティング** — 現状 CTA は /learn へ直行（#7 で法的告知は揃っている）

## 関連 / Related
Closes #31
- #7（Terms/Privacy）マージ済みが前提
- \`docs/open-issues-decisions.md\` の #31 セクションを参照
- コピー調整 PR を次に切る想定