### PR TITLE
[Fix] /terms and /privacy: English primary, JA toggle

### DIFF
--- a/training_field/web/templates/legal/base.html
+++ b/training_field/web/templates/legal/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="ja">
+<html lang="en">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
@@ -26,11 +26,21 @@ body{
   line-height:1.7;font-size:15px;
 }
 .legal-wrap{max-width:760px;margin:0 auto}
+.top-bar{
+  display:flex;align-items:center;justify-content:space-between;
+  margin-bottom:24px;
+}
 .back-link{
-  display:inline-block;color:var(--muted);text-decoration:none;
-  font-size:13px;margin-bottom:24px;
+  color:var(--muted);text-decoration:none;font-size:13px;
 }
 .back-link:hover{color:var(--text)}
+.lang-btn{
+  background:var(--surface-2);color:var(--text-secondary);
+  border:1px solid var(--border);border-radius:var(--radius-pill);
+  padding:6px 14px;font-size:12px;cursor:pointer;font-family:inherit;
+  transition:background 0.15s var(--ease);
+}
+.lang-btn:hover{background:var(--border-strong);color:var(--text)}
 h1{font-size:28px;letter-spacing:-0.02em;margin:0 0 8px}
 h2{font-size:18px;letter-spacing:-0.01em;margin-top:32px;padding-top:20px;border-top:1px solid var(--border)}
 h2:first-of-type{border-top:none;padding-top:0}
@@ -51,19 +61,64 @@ hr{border:none;border-top:1px solid var(--border);margin:40px 0}
 }
 .legal-banner strong{color:var(--warning)}
 em{color:var(--muted)}
+
+/* Language toggling — show the active language, hide the other */
+[data-lang-block]{display:none}
+:root[data-legal-lang="en"] [data-lang-block="en"]{display:block}
+:root[data-legal-lang="ja"] [data-lang-block="ja"]{display:block}
 </style>
 </head>
 <body>
-<script>(function(){var t=localStorage.getItem("tfTheme")||"light";document.documentElement.setAttribute("data-theme",t);})();</script>
+<script>
+(function(){
+  var t = localStorage.getItem("tfTheme") || "light";
+  document.documentElement.setAttribute("data-theme", t);
+  var l = localStorage.getItem("tfLang") || "en";
+  if (l !== "ja") l = "en";
+  document.documentElement.setAttribute("data-legal-lang", l);
+  document.documentElement.lang = l;
+})();
+</script>
 <div class="legal-wrap">
-  <a href="/" class="back-link">← Toy Alchemy</a>
+  <div class="top-bar">
+    <a href="/" class="back-link">← Toy Alchemy</a>
+    <button class="lang-btn" id="langbtn" onclick="toggleLegalLang()">JA</button>
+  </div>
+
   {% block content %}{% endblock %}
+
   <hr />
   <p style="font-size:12px;color:var(--muted)">
-    <a href="/terms">利用規約 / Terms</a> ·
-    <a href="/privacy">プライバシーポリシー / Privacy</a> ·
+    <a href="/terms" data-lang-block="en">Terms</a>
+    <a href="/terms" data-lang-block="ja">利用規約</a>
+    ·
+    <a href="/privacy" data-lang-block="en">Privacy</a>
+    <a href="/privacy" data-lang-block="ja">プライバシー</a>
+    ·
     <a href="https://github.com/rojoma/toy-alchemy" target="_blank" rel="noopener">GitHub</a>
   </p>
 </div>
+<script>
+function toggleLegalLang(){
+  var cur = document.documentElement.getAttribute("data-legal-lang") || "en";
+  var next = cur === "ja" ? "en" : "ja";
+  document.documentElement.setAttribute("data-legal-lang", next);
+  document.documentElement.lang = next;
+  localStorage.setItem("tfLang", next);
+  var btn = document.getElementById("langbtn");
+  if (btn) btn.textContent = next === "ja" ? "EN" : "JA";
+  // Update page title: first H1 of the active block
+  var activeH1 = document.querySelector('[data-lang-block="' + next + '"] h1');
+  if (activeH1) document.title = activeH1.textContent + " — Toy Alchemy";
+}
+// Set initial button label
+(function(){
+  var cur = document.documentElement.getAttribute("data-legal-lang") || "en";
+  var btn = document.getElementById("langbtn");
+  if (btn) btn.textContent = cur === "ja" ? "EN" : "JA";
+  var activeH1 = document.querySelector('[data-lang-block="' + cur + '"] h1');
+  if (activeH1) document.title = activeH1.textContent + " — Toy Alchemy";
+})();
+</script>
 </body>
 </html>

--- a/training_field/web/templates/legal/privacy.html
+++ b/training_field/web/templates/legal/privacy.html
@@ -1,11 +1,128 @@
 {% extends "legal/base.html" %}
-{% set page_title = "プライバシーポリシー / Privacy Policy" %}
+{% set page_title = "Privacy Policy" %}
 {% block content %}
 
 <div class="legal-banner">
-  <strong>⚠ ドラフト / Draft status.</strong>
-  本書はエンジニアによる初稿であり、法律家のレビューを受けていません。公開前に弁護士または教育法務の専門家による確認が必要です。内容の最終責任は Toy Alchemy プロジェクト運営者にあります。
+  <strong>⚠ Draft.</strong>
+  This is an engineer's initial draft. It has not been reviewed by a lawyer.
+  Before any public launch, this document should be reviewed by qualified legal
+  counsel (education-law specialist recommended).
 </div>
+
+<!-- ────────────── ENGLISH ────────────── -->
+<div data-lang-block="en">
+
+<h1>Privacy Policy</h1>
+<p class="last-updated">Last updated: 2026-04-23 (draft v0.1)</p>
+
+<p>Toy Alchemy (the “Service”) handles personal information under the policy below. Because the Service is an AI-tutor platform that is used by minors, we take extra care.</p>
+
+<h2>1. Operator</h2>
+<p>MIT MAS.664 AI Studio, Spring 2026 — Team Toy Alchemy ({{ contact_email or "TBD: operator contact email to be added" }}).</p>
+
+<h2>2. What we collect</h2>
+
+<h3>2.1 Information the student enters directly</h3>
+<ul>
+  <li>Name or nickname (student-chosen)</li>
+  <li>Grade (primary 1 through high-school 3)</li>
+  <li>Subject (math, Japanese, science, social studies, English)</li>
+  <li>Learning topic and scope (free text)</li>
+  <li>Messages typed during a session (questions to the teacher, answers, etc.)</li>
+  <li>Optional post-session feedback (5-point rating, tags, free text)</li>
+  <li>Optional per-turn feedback (👍 / ❓ / 👎)</li>
+  <li>Optional uploaded photos of homework / textbook pages — see §2.4 below</li>
+</ul>
+
+<h3>2.2 Information generated automatically</h3>
+<ul>
+  <li>Session ID (randomly generated)</li>
+  <li>Proficiency scores (per topic)</li>
+  <li>AI evaluation signals (ZPD alignment, Bloom level, clarity, etc.)</li>
+  <li>Session-history timestamps</li>
+  <li>Teacher Memory (per-student observational notes held by the AI teacher)</li>
+</ul>
+
+<h3>2.3 Information stored in the browser (LocalStorage)</h3>
+<ul>
+  <li>Anonymous student ID</li>
+  <li>Selected teacher ID</li>
+  <li>Language setting (en / ja)</li>
+  <li>Theme setting (light / dark)</li>
+</ul>
+<p>This information is stored in the user's browser and may not be transmitted to our server. It can be cleared from the browser settings.</p>
+
+<h3>2.4 Uploaded photos</h3>
+<p>Students may optionally upload a photo of a homework sheet or textbook page to help describe the learning scope.</p>
+<ul>
+  <li>Uploaded images are sent to OpenAI (USA) for image analysis only.</li>
+  <li>We do <strong>not retain</strong> the image file on our server. It is discarded immediately after inference.</li>
+  <li>Only the short textual description extracted from the image is saved as the session scope.</li>
+  <li>Please do not include personally identifying information (names, addresses, photos of faces, etc.) in the image.</li>
+</ul>
+
+<h2>3. Purposes of use</h2>
+<ul>
+  <li>Provide personalized AI-based learning instruction.</li>
+  <li>Show the student their learning progress.</li>
+  <li>Improve how the AI teachers teach (aggregate analysis).</li>
+  <li>Publish research results (MIT MAS.664 AI Studio coursework and academic publication — any public disclosure will be de-identified).</li>
+  <li>Investigate bugs and improve service quality.</li>
+</ul>
+
+<h2>4. Sharing with third parties</h2>
+<p>We share information only with the following processors, to the minimum extent necessary for operating the Service.</p>
+<ul>
+  <li><strong>OpenAI</strong> (USA): session dialogue is sent for AI model inference. Per the API agreement, OpenAI does not use this data to train its models.</li>
+  <li><strong>Railway</strong> (USA): hosting and persistent storage.</li>
+</ul>
+<p>We do not share personal information with any other third party (except as required by law).</p>
+
+<h2>5. Cross-border transfer</h2>
+<p>As noted above, data is transmitted to and stored on US-based services. By using the Service, users consent to this cross-border transfer.</p>
+
+<h2>6. Retention</h2>
+<p>The following data is retained until a deletion request is received:</p>
+<ul>
+  <li>Student profiles</li>
+  <li>Session history and evaluation reports</li>
+  <li>Feedback records</li>
+</ul>
+<p>TBD: a specific retention window (e.g. 1 year, or until graduation) will be set as operational policy.</p>
+
+<h2>7. Deletion and disclosure requests</h2>
+<p>Students or their parents/guardians may request:</p>
+<ul>
+  <li>Disclosure of information we hold about them.</li>
+  <li>Correction or deletion of that information.</li>
+  <li>Suspension of service use.</li>
+</ul>
+<p>Please contact {{ contact_email or "TBD: operator contact email" }}. We will respond within a reasonable period after verifying identity.</p>
+
+<h2>8. Minors and parental consent</h2>
+<p>The Service is designed for minor users (under 18).</p>
+<p>TBD: the specific consent mechanism (consent dialog, email confirmation, written consent, etc.) and when it is enforced remain open. This draft simply requests that parental consent be obtained before use.</p>
+
+<h2>9. Security</h2>
+<ul>
+  <li>API keys and other credentials are managed via environment variables and are not committed to the repository.</li>
+  <li>Communication is encrypted using HTTPS (Railway default).</li>
+  <li>Database access is limited to the operator and the service processes.</li>
+</ul>
+
+<h2>10. Cookies and local storage</h2>
+<p>The Service uses cookies or LocalStorage to maintain an authenticated session. Users may disable these in browser settings, though doing so may break some functionality.</p>
+
+<h2>11. Changes to this Policy</h2>
+<p>This Policy may be revised in response to changes in law or in the Service. Significant changes will be announced on this page.</p>
+
+<h2>12. Contact</h2>
+<p>{{ contact_email or "TBD: operator contact email to be added" }}</p>
+
+</div>
+
+<!-- ────────────── 日本語 ────────────── -->
+<div data-lang-block="ja">
 
 <h1>プライバシーポリシー</h1>
 <p class="last-updated">最終更新: 2026-04-23（ドラフト v0.1）</p>
@@ -29,15 +146,6 @@
   <li>宿題・教科書の写真（任意アップロード）— 下記 2.4 をご覧ください</li>
 </ul>
 
-<h3>2.4 写真アップロードの取り扱い</h3>
-<p>生徒は学習範囲を指定する方法として、宿題プリントや教科書ページの写真をアップロードできます（任意機能）。</p>
-<ul>
-  <li>アップロードされた画像は、学習範囲を要約する目的でOpenAI（米国）の画像解析APIに送信されます。</li>
-  <li>本サービスは画像ファイルそのものを <strong>保存しません</strong>。推論完了後は速やかに破棄します。</li>
-  <li>画像から抽出された短い説明テキストのみが、セッションの学習範囲として保存されます。</li>
-  <li>アップロードされる画像に個人を特定できる情報（氏名、住所、顔写真等）が含まれないよう、利用者側でご注意ください。</li>
-</ul>
-
 <h3>2.2 利用に伴い自動生成される情報</h3>
 <ul>
   <li>セッションID（ランダム生成）</li>
@@ -55,6 +163,15 @@
   <li>テーマ設定（light / dark）</li>
 </ul>
 <p>これらは利用者のブラウザに保存され、サーバーには送信されない場合があります。ブラウザの設定で削除可能です。</p>
+
+<h3>2.4 写真アップロードの取り扱い</h3>
+<p>生徒は学習範囲を指定する方法として、宿題プリントや教科書ページの写真をアップロードできます（任意機能）。</p>
+<ul>
+  <li>アップロードされた画像は、学習範囲を要約する目的でOpenAI（米国）の画像解析APIに送信されます。</li>
+  <li>本サービスは画像ファイルそのものを <strong>保存しません</strong>。推論完了後は速やかに破棄します。</li>
+  <li>画像から抽出された短い説明テキストのみが、セッションの学習範囲として保存されます。</li>
+  <li>アップロードされる画像に個人を特定できる情報（氏名、住所、顔写真等）が含まれないよう、利用者側でご注意ください。</li>
+</ul>
 
 <h2>3. 利用目的</h2>
 <ul>
@@ -114,10 +231,6 @@
 <h2>12. お問い合わせ</h2>
 <p>{{ contact_email or "TBD: 運営代表メールアドレスを記載" }}</p>
 
-<hr />
-
-<h2 id="english">English (summary)</h2>
-<p><em>This English summary is for convenience only. The Japanese version above is authoritative.</em></p>
-<p>Toy Alchemy is an AI tutoring platform built for MIT MAS.664 AI Studio, Spring 2026. Data we collect includes: student nickname, grade/subject, session dialogue with the AI tutor, proficiency scores, and optional feedback. Data is sent to OpenAI (AI inference) and stored on Railway (US hosting). Data is not sold or shared beyond these service providers. Users may request disclosure, correction, or deletion of their data by emailing us. This service is intended for minors; parental consent is expected. This is a <strong>draft document pending legal review</strong>.</p>
+</div>
 
 {% endblock %}

--- a/training_field/web/templates/legal/terms.html
+++ b/training_field/web/templates/legal/terms.html
@@ -1,11 +1,88 @@
 {% extends "legal/base.html" %}
-{% set page_title = "利用規約 / Terms of Service" %}
+{% set page_title = "Terms of Service" %}
 {% block content %}
 
 <div class="legal-banner">
-  <strong>⚠ ドラフト / Draft status.</strong>
-  本書はエンジニアによる初稿であり、法律家のレビューを受けていません。公開前に弁護士または教育法務の専門家による確認が必要です。
+  <strong>⚠ Draft.</strong>
+  This is an engineer's initial draft. It has not been reviewed by a lawyer.
+  Before any public launch, this document should be reviewed by qualified legal
+  counsel (education-law specialist recommended).
 </div>
+
+<!-- ────────────── ENGLISH ────────────── -->
+<div data-lang-block="en">
+
+<h1>Terms of Service</h1>
+<p class="last-updated">Last updated: 2026-04-23 (draft v0.1)</p>
+
+<h2>1. Purpose</h2>
+<p>These Terms of Service (“Terms”) govern use of Toy Alchemy (the “Service”). By using the Service, you agree to these Terms.</p>
+
+<h2>2. Operator</h2>
+<p>MIT MAS.664 AI Studio, Spring 2026 — Team Toy Alchemy ({{ contact_email or "TBD: operator contact email to be added" }}).</p>
+
+<h2>3. What the Service is</h2>
+<p>The Service is an online AI tutor, currently focused on primary-school mathematics, provided as part of an educational research project. It is not a substitute for school instruction.</p>
+
+<h2>4. Age and parental consent</h2>
+<p>The Service is designed for minor users. Users under 18 should use the Service with the consent of a parent or legal guardian.</p>
+<p>TBD: the specific consent flow (consent modal, email verification, written consent, etc.) and when to enforce it are operational decisions pending.</p>
+
+<h2>5. Fees</h2>
+<p>The Service is currently free. If we ever introduce fees, we will announce the change in advance.</p>
+
+<h2>6. Nature of AI-generated instruction</h2>
+<p>The Service uses large language models to generate its responses. Please be aware that:</p>
+<ul>
+  <li>AI responses may contain errors or inappropriate content.</li>
+  <li>Content may not exactly match school curricula or textbooks.</li>
+  <li>Important learning decisions should be confirmed with a parent or teacher.</li>
+  <li>Use of the Service does not guarantee academic outcomes or qualifications.</li>
+</ul>
+
+<h2>7. User responsibilities</h2>
+<ul>
+  <li>Do not post content that defames or harasses other users or the operator.</li>
+  <li>Do not submit information that infringes third parties' personal data or copyright.</li>
+  <li>Do not redistribute the Service for commercial purposes (the repository's MIT license still applies to the code).</li>
+  <li>Do not attempt unauthorized access or generate excessive load against the Service.</li>
+</ul>
+
+<h2>8. Prohibited conduct</h2>
+<ul>
+  <li>Interfering with the operation of the Service.</li>
+  <li>Unauthorized acquisition of other users' data.</li>
+  <li>Any activity that violates applicable law or public order and morals.</li>
+  <li>Reverse-engineering to exploit vulnerabilities (responsible vulnerability disclosure is welcome).</li>
+</ul>
+
+<h2>9. Intellectual property</h2>
+<p>The Service's source code is published on <a href="https://github.com/rojoma/toy-alchemy" target="_blank" rel="noopener">GitHub</a>. Rights in AI-generated content (e.g. the AI teacher's messages) follow the generative-AI provider's terms of service at the time of generation.</p>
+
+<h2>10. Disclaimers</h2>
+<ul>
+  <li>The Service is provided as part of AI research. No commercial-grade SLA is guaranteed.</li>
+  <li>The operator is not liable for any direct or indirect damages arising from use of the Service.</li>
+  <li>The Service may be suspended or modified without notice.</li>
+</ul>
+
+<h2>11. Data handling</h2>
+<p>Handling of user data is governed by the <a href="/privacy">Privacy Policy</a>.</p>
+
+<h2>12. Changes to these Terms</h2>
+<p>We may revise these Terms as needed. Significant changes will be announced on this page.</p>
+
+<h2>13. Governing law and jurisdiction</h2>
+<p>These Terms are governed by the laws of Japan. Any dispute arising in connection with the Service shall be subject to the exclusive jurisdiction of the Tokyo District Court as the court of first instance.</p>
+<p>TBD: if we expand distribution to the US, the jurisdiction clause should be reviewed (see <code>docs/open-issues-decisions.md</code>, issue #7).</p>
+
+<h2>14. Contact</h2>
+<p>{{ contact_email or "TBD: operator contact email" }}</p>
+
+</div>
+
+<!-- ────────────── 日本語 ────────────── -->
+<div data-lang-block="ja">
 
 <h1>利用規約</h1>
 <p class="last-updated">最終更新: 2026-04-23（ドラフト v0.1）</p>
@@ -71,15 +148,11 @@
 
 <h2>13. 準拠法・管轄</h2>
 <p>本規約は日本法に準拠するものとし、本サービスに関する紛争は東京地方裁判所を第一審の専属的合意管轄とします。</p>
-<p>TBD: 米国での利用も視野に入れる場合は、管轄条項の再検討が必要です（#7 決定メモ参照）。</p>
+<p>TBD: 米国での利用も視野に入れる場合は、管轄条項の再検討が必要です（<code>docs/open-issues-decisions.md</code> 参照）。</p>
 
 <h2>14. お問い合わせ</h2>
 <p>{{ contact_email or "TBD: 運営代表メールアドレスを記載" }}</p>
 
-<hr />
-
-<h2 id="english">English (summary)</h2>
-<p><em>This English summary is for convenience only. The Japanese version above is authoritative.</em></p>
-<p>Toy Alchemy is an AI tutoring service for educational research. The service is free, may contain errors typical of AI-generated content, and is not a substitute for formal education. Users under 18 should use with parental consent. Governing law: Japan. Data handling follows our <a href="/privacy">Privacy Policy</a>. This is a <strong>draft document pending legal review</strong>.</p>
+</div>
 
 {% endblock %}


### PR DESCRIPTION
## 背景 / Why
ご指摘の通り、legal ページだけが「日本語原文 + 英語要約」の構成になっていてアプリ全体の EN 基準とズレていました。このPRで legal ページも **English primary / JA toggle** に揃えます。

## 方式 / Approach
landing page と同じ思想で、**両言語の完全版ドキュメントを同時にレンダリング**し、\`[data-lang-block="en|ja"]\` 属性で片方を非表示にする CSS + \`tfLang\` localStorage で制御。\`tfLang\` は他ページと共通なので、\`/learn\` で JA を選んだユーザーが legal に飛んでも JA が維持されます。

## 変更 / Changes

### \`legal/base.html\`
- Top-bar に JA/EN トグルボタン追加
- \`data-legal-lang\` 属性で en/ja ブロックの表示切替（inline CSS）
- \`<html lang>\` と \`<title>\` がアクティブな言語に応じて更新
- Footer の Terms/Privacy リンクも両言語版を持ち、切替で入れ替わる

### \`legal/terms.html\`
- \`[data-lang-block="en"]\` に **完全な英語版** 14セクション（旧：1パラグラフ要約のみ）
- \`[data-lang-block="ja"]\` に 日本語版（旧から変更なし）
- 両言語で同じ構造・同じ条項（governing law、operator、consent、etc.）

### \`legal/privacy.html\`
- \`[data-lang-block="en"]\` に **完全な英語版** 12セクション
- \`[data-lang-block="ja"]\` に 日本語版（旧から変更なし）
- §2.4 写真アップロード（#32 で追記したもの）も両言語に反映

## 日本語テキストの扱い / Japanese preservation
**日本語セクションは前回のスケルトン PR からの変更なし**。既に日本の法務確認を受けている場合でも再確認は不要。英語版は新規翻訳なので、公開前の法務レビューが必要（ドラフトバナーで明示）。

## 検証 / Testing
- [x] \`/terms\` / \`/privacy\` 両方で EN + JA ブロックが存在
- [x] \`data-legal-lang\` 属性による CSS 表示切替が動作
- [x] \`tfLang\` localStorage で他ページと言語選択を共有
- [x] ドラフトバナー、footer リンク、\`<title>\` / \`<html lang>\` 更新すべて動作
- [ ] Live: JA トグルで全文が日本語に切り替わるか（deploy 後）
- [ ] Live: landing で JA 選択 → /terms 遷移後も JA が維持されるか

## 関連 / Related
- 前 PR #47 の scope 変更（JA primary → EN primary）
- 前 PR #50（landing EN化）、PR #51（footer i18n）との整合