### PR TITLE
[Feature] Teacher picker: show what makes each teacher different

### DIFF
--- a/training_field/teacher_registry.py
+++ b/training_field/teacher_registry.py
@@ -20,8 +20,103 @@ _INTERNAL_FACTORIES = {
 }
 
 
+def _warmth_tier(v: float) -> str:
+    if v >= 0.85: return "very_warm"
+    if v >= 0.65: return "warm"
+    if v >= 0.4: return "balanced"
+    return "cool"
+
+
+def _formality_tier(v: float) -> str:
+    if v >= 0.7: return "formal"
+    if v >= 0.45: return "neutral"
+    return "casual"
+
+
+def _pace_tier(v: float) -> str:
+    if v >= 0.55: return "brisk"
+    if v >= 0.4: return "steady"
+    return "slow"
+
+
+def _persona_preview(c) -> dict:
+    """User-facing summary: what makes this teacher different from the others?
+
+    Converts internal TeacherConfig parameters into tags and a plain-English
+    tagline that a student or parent can actually use to pick one.
+    """
+    warmth = _warmth_tier(c.warmth)
+    formality = _formality_tier(c.formality)
+    pace = _pace_tier(c.pacing_speed)
+    patience = "patient" if c.patience_threshold >= 4 else "brisk"
+    motivation = c.motivation_style  # "challenge" | "encouragement" | "mastery"
+
+    # Traits: short chips the UI shows on the teacher card.
+    traits: list[dict] = []
+    if warmth == "very_warm":
+        traits.append({"key": "warm", "icon": "💗", "label_en": "Very warm", "label_ja": "とてもやさしい"})
+    elif warmth == "warm":
+        traits.append({"key": "warm", "icon": "😊", "label_en": "Warm", "label_ja": "やさしい"})
+    elif warmth == "cool":
+        traits.append({"key": "cool", "icon": "🧊", "label_en": "Cool & direct", "label_ja": "クールで率直"})
+
+    if formality == "formal":
+        traits.append({"key": "formal", "icon": "🎓", "label_en": "Formal", "label_ja": "丁寧"})
+    elif formality == "casual":
+        traits.append({"key": "casual", "icon": "🗣️", "label_en": "Casual", "label_ja": "くだけた"})
+
+    if patience == "patient":
+        traits.append({"key": "patient", "icon": "🕰️", "label_en": "Patient with mistakes", "label_ja": "間違いに寛容"})
+
+    if motivation == "challenge":
+        traits.append({"key": "challenges", "icon": "🔥", "label_en": "Challenges you", "label_ja": "チャレンジを促す"})
+    elif motivation == "encouragement":
+        traits.append({"key": "cheers", "icon": "📣", "label_en": "Cheers you on", "label_ja": "はげましてくれる"})
+    elif motivation == "mastery":
+        traits.append({"key": "mastery", "icon": "🎯", "label_en": "Mastery-focused", "label_ja": "じっくり完成させる"})
+
+    if pace == "slow":
+        traits.append({"key": "slow", "icon": "🐢", "label_en": "Slow and steady", "label_ja": "ゆっくりじっくり"})
+    elif pace == "brisk":
+        traits.append({"key": "brisk", "icon": "⚡", "label_en": "Brisk pace", "label_ja": "テンポよく"})
+
+    if "socratic_questioning" in c.selected_skills:
+        traits.append({"key": "socratic", "icon": "❓", "label_en": "Asks questions", "label_ja": "問いかけてくれる"})
+    if "stepwise_decomposition" in c.selected_skills:
+        traits.append({"key": "stepwise", "icon": "🪜", "label_en": "Step-by-step", "label_ja": "一歩ずつ"})
+    if "concrete_examples" in c.selected_skills:
+        traits.append({"key": "examples", "icon": "🍎", "label_en": "Real examples", "label_ja": "身近な例で"})
+
+    # Derive a single tagline from the dominant traits. Short, student-facing.
+    if motivation == "encouragement" and warmth in ("warm", "very_warm"):
+        tagline_en = "Your encouraging cheerleader."
+        tagline_ja = "やさしく応援してくれる先生。"
+    elif motivation == "mastery" and pace == "slow":
+        tagline_en = "Patient, step-by-step coach."
+        tagline_ja = "一歩ずつ、しっかり確認する先生。"
+    elif motivation == "challenge" and warmth == "cool":
+        tagline_en = "Sharp challenger. No fluff."
+        tagline_ja = "きびしめで、実力勝負の先生。"
+    elif motivation == "challenge":
+        tagline_en = "Curious questioner who pushes you to think."
+        tagline_ja = "問いかけて考えさせてくれる先生。"
+    elif warmth == "very_warm":
+        tagline_en = "Warm and welcoming — great if you're nervous."
+        tagline_ja = "あったかい雰囲気。緊張しがちな子に。"
+    else:
+        tagline_en = "Balanced and approachable."
+        tagline_ja = "バランス型の先生。"
+
+    return {
+        "tagline_en": tagline_en,
+        "tagline_ja": tagline_ja,
+        "traits": traits,
+    }
+
+
 def _summarize(agent: TeacherAgent) -> dict:
     c = agent.config
+    persona = _persona_preview(c)
     return {
         "teacher_id": c.teacher_id,
         "name": c.name,
@@ -31,6 +126,10 @@ def _summarize(agent: TeacherAgent) -> dict:
         "formality": c.formality,
         "patience_threshold": c.patience_threshold,
         "selected_skills": list(c.selected_skills),
+        # User-facing derived fields (#10 groundwork):
+        "tagline_en": persona["tagline_en"],
+        "tagline_ja": persona["tagline_ja"],
+        "traits": persona["traits"],
     }
 
 

--- a/training_field/web/templates/learn.html
+++ b/training_field/web/templates/learn.html
@@ -153,6 +153,41 @@ h1{font-size:28px;font-weight:600;letter-spacing:-0.025em;margin-bottom:8px}
 .scope-status.ok{background:rgba(31,138,76,0.12);color:var(--success, #1f8a4c)}
 .scope-status.err{background:rgba(193,39,45,0.1);color:var(--danger, #c1272d)}
 .scope-status.busy{background:var(--surface-2);color:var(--muted)}
+
+/* Teacher picker (#10 groundwork) — replaces the flat select */
+.teacher-picker{display:flex;flex-direction:column;gap:8px}
+.teacher-card{
+  border:1.5px solid var(--border);border-radius:12px;
+  background:var(--surface);padding:12px 14px;cursor:pointer;
+  transition:border-color .15s var(--ease), background .15s var(--ease);
+}
+.teacher-card:hover{border-color:var(--border-strong)}
+.teacher-card:focus{outline:none;border-color:var(--text)}
+.teacher-card.selected{
+  border-color:var(--text);
+  background:var(--surface-2);
+}
+.teacher-head{display:flex;align-items:center;gap:10px;margin-bottom:6px}
+.teacher-avatar{
+  width:32px;height:32px;border-radius:50%;
+  background:var(--text);color:var(--bg);
+  display:flex;align-items:center;justify-content:center;
+  font-size:14px;font-weight:600;flex-shrink:0;
+}
+.teacher-name{font-size:14px;font-weight:600;letter-spacing:-0.01em}
+.teacher-tagline{
+  font-size:12px;color:var(--text-secondary);
+  margin-bottom:8px;line-height:1.45;
+}
+.teacher-traits{display:flex;flex-wrap:wrap;gap:4px}
+.teacher-trait{
+  font-size:10px;padding:3px 8px;border-radius:10px;
+  background:var(--surface-2);color:var(--text-secondary);
+  font-weight:500;
+}
+.teacher-card.selected .teacher-trait{
+  background:var(--surface);
+}
 </style>
 </head>
 <body>
@@ -211,11 +246,29 @@ h1{font-size:28px;font-weight:600;letter-spacing:-0.025em;margin-bottom:8px}
   </div>
   <div class="form-group">
     <label class="form-label" data-i18n="label_teacher">TEACHER</label>
-    <select class="form-select" id="teacherSelect">
+    <div class="teacher-picker" id="teacherPicker" role="radiogroup">
       {% for t in teachers %}
-      <option value="{{ t.teacher_id }}">{{ t.name }} — {{ t.origin }}</option>
+      <div class="teacher-card" role="radio" tabindex="0"
+           data-teacher-id="{{ t.teacher_id }}"
+           data-tagline-en="{{ t.tagline_en or '' }}"
+           data-tagline-ja="{{ t.tagline_ja or '' }}">
+        <div class="teacher-head">
+          <div class="teacher-avatar">{{ t.name[:1] }}</div>
+          <div class="teacher-name">{{ t.name }}</div>
+        </div>
+        <div class="teacher-tagline"
+             data-en="{{ t.tagline_en or '' }}"
+             data-ja="{{ t.tagline_ja or '' }}">{{ t.tagline_en or '' }}</div>
+        <div class="teacher-traits">
+          {% for trait in t.traits or [] %}
+          <span class="teacher-trait"
+                data-en="{{ trait.label_en }}"
+                data-ja="{{ trait.label_ja }}">{{ trait.icon }} {{ trait.label_en }}</span>
+          {% endfor %}
+        </div>
+      </div>
       {% endfor %}
-    </select>
+    </div>
   </div>
   <div class="form-group">
     <label class="form-label" data-i18n="label_scope">LEARNING SCOPE (OPTIONAL)</label>
@@ -356,6 +409,7 @@ function applyLang(l){
   if(b) b.textContent = (l==="ja") ? "EN" : "JA";
   fillGradeSubject(l);
   refreshTopicLabels(l);
+  refreshTeacherLabels(l);
   // Re-render dynamic welcome strings if visible
   const wel = document.getElementById("welcome");
   if(wel && wel.style.display !== "none" && window._lastProfile){
@@ -508,9 +562,8 @@ function showWelcome(profile){
       topicSel.appendChild(other);
     });
 
-  // Restore saved teacher
-  const savedTeacher = localStorage.getItem("tfStudentTeacher");
-  if(savedTeacher) document.getElementById("teacherSelect").value = savedTeacher;
+  // Wire teacher cards (#10 groundwork)
+  initTeacherPicker();
 
   // History
   const list = document.getElementById("historyList");
@@ -539,9 +592,54 @@ function onTopicChange(){
   }
 }
 
+// ── Teacher picker ────────────────────────────────────
+let selectedTeacherId = null;
+function initTeacherPicker(){
+  const cards = document.querySelectorAll(".teacher-card");
+  if(cards.length === 0) return;
+  const saved = localStorage.getItem("tfStudentTeacher");
+  let initial = null;
+  cards.forEach(card=>{
+    if(card.dataset.teacherId === saved) initial = card;
+    card.addEventListener("click", ()=>selectTeacher(card));
+    card.addEventListener("keydown", e=>{
+      if(e.key === "Enter" || e.key === " "){
+        e.preventDefault();
+        selectTeacher(card);
+      }
+    });
+  });
+  selectTeacher(initial || cards[0]);
+  // Apply current language labels to trait chips + tagline
+  refreshTeacherLabels(curLang);
+}
+function selectTeacher(card){
+  if(!card) return;
+  document.querySelectorAll(".teacher-card").forEach(c=>{
+    c.classList.remove("selected");
+    c.setAttribute("aria-checked", "false");
+  });
+  card.classList.add("selected");
+  card.setAttribute("aria-checked", "true");
+  selectedTeacherId = card.dataset.teacherId;
+}
+function refreshTeacherLabels(lang){
+  document.querySelectorAll(".teacher-tagline").forEach(el=>{
+    const v = el.dataset[lang];
+    if(v) el.textContent = v;
+  });
+  document.querySelectorAll(".teacher-trait").forEach(el=>{
+    const v = el.dataset[lang];
+    if(!v) return;
+    // Keep the leading emoji/icon (first token before space).
+    const first = el.textContent.split(" ")[0];
+    el.textContent = first + " " + v;
+  });
+}
+
 function startSession(){
   const sid = localStorage.getItem("tfStudentId");
-  const teacher = document.getElementById("teacherSelect").value;
+  const teacher = selectedTeacherId || localStorage.getItem("tfStudentTeacher") || "t001";
   const sel = document.getElementById("topicSelect");
   let topic = sel.value;
   if(topic === "__custom__"){


### PR DESCRIPTION
## 問題 / Issue
現在の teacher プルダウンは "Dr. Owen — internal" や "Warm Coach — experiment_2_h2" のような**エンジニア向けメタデータ**を表示していました。生徒・保護者から見ると「どう違うの？」が一切わからない。スクリーンショットで指摘いただきました。

## 変更 / Changes

### UI — \`/learn\`
flat \`<select>\` を **カード型ピッカー** (role="radiogroup") に置換。各カードに:
- **Avatar** + **Name**
- **1行のタグライン** (例: "Patient, step-by-step coach.", "Sharp challenger. No fluff.")
- **3〜6個のトレイトチップ** (例: 💗 Very warm / 🕰️ Patient with mistakes / 🔥 Challenges you / 🪜 Step-by-step / 🍎 Real examples)

Keyboard 対応 (Enter/Space で選択)、選択状態は \`tfStudentTeacher\` localStorage（既存キー）、lang トグル時は en/ja ラベルがインプレース切替。

### Backend — \`teacher_registry.py\`
\`_summarize()\` にユーザー向け派生フィールドを追加。ハードコードなしで **既存の TeacherConfig から自動生成**:
- \`_warmth_tier()\` / \`_formality_tier()\` / \`_pace_tier()\` が連続値を質的バケットに
- \`motivation_style\` + \`frustration_handling\` + \`selected_skills\` からトレイトを選択
- タグラインは (motivation, warmth, pace) の支配的な組合せで決定

**新しい external teacher JSON を追加しても、カードは自動生成される**（#10 の基盤にもなる）。

### 先生ごとの自動生成結果（現5人）
| Teacher | Tagline | Traits |
|---|---|---|
| Dr. Owen | Curious questioner who pushes you to think. | 😊 Warm · 🗣️ Casual · 🔥 Challenges you · ❓ Asks questions |
| Cool Coach | Sharp challenger. No fluff. | 🧊 Cool & direct · 🎓 Formal · 🔥 Challenges you · 🍎 Real examples |
| Ms. Rivera | Your encouraging cheerleader. | 💗 Very warm · 🗣️ Casual · 🕰️ Patient with mistakes · 📣 Cheers you on · ⚡ Brisk · 🍎 Real examples |
| Prof. Tanaka | Patient, step-by-step coach. | 🎓 Formal · 🕰️ Patient · 🎯 Mastery · 🐢 Slow and steady · 🪜 Step-by-step · 🍎 Real examples |
| Warm Coach | Your encouraging cheerleader. | 💗 Very warm · 🗣️ Casual · 🕰️ Patient · 📣 Cheers you on · 🍎 Real examples |

## 検証 / Testing
- [x] py_compile
- [x] \`/learn\` レスポンスに 5 枚のカードと data-teacher-id、tagline/traits が描画される
- [x] 旧 \`teacherSelect\` 参照は消えている
- [x] \`startSession()\` が \`selectedTeacherId\` を読むように更新
- [ ] Live: カードクリックで選択状態が入れ替わる
- [ ] Live: JA トグルでタグラインとトレイトが日本語に入れ替わる
- [ ] Live: \`tfStudentTeacher\` localStorage で次回アクセス時の選択復元

## 関連 / Related
- #10（教師選択ガイド）の実装の基盤（タグライン＋トレイト derivation が完成、将来の "おすすめ" 機能はこの上に乗せられる）
- #29（セッション後フィードバック）データが溜まれば、tagline/trait の妥当性検証もできる