### PR TITLE
Surface derived StudentAgents in the Observatory (fix #63)

### DIFF
--- a/training_field/student_agent.py
+++ b/training_field/student_agent.py
@@ -183,6 +183,67 @@ class StudentAgentFactory:
         )
 
     @staticmethod
+    def from_derived_profile(profile_path: Path, *, display_name: str | None = None) -> StudentAgent:
+        """Build a StudentAgent from a real student's derived block (#63).
+
+        `profile_path` is the JSON file at reports/students/{id}.json. The
+        file must already have a `derived` block with the personality +
+        signals fields produced by student_profile_deriver (#62).
+
+        `display_name` overrides the student's real name in the agent
+        (e.g. "Student #4") to avoid leaking PII when the agent is shown
+        to other users.
+        """
+        with open(profile_path, encoding="utf-8") as f:
+            profile = json.load(f)
+        derived = profile.get("derived") or {}
+        personality = dict(derived.get("personality") or {})
+        # Fill defaults so the existing prompt builder doesn't KeyError.
+        personality.setdefault("curiosity", 0.5)
+        personality.setdefault("patience", 0.5)
+        personality.setdefault("confidence", 0.5)
+        personality.setdefault("verbosity", 0.3)
+        personality.setdefault("description", "Auto-derived from real session data.")
+
+        # Proficiency: prefer the per-topic map the user accumulated through
+        # /api/student/{id}/update-proficiency. Fall back to a single 50.
+        topic_profs = dict(profile.get("proficiency") or {})
+        avg_prof = (
+            sum(topic_profs.values()) / len(topic_profs)
+            if topic_profs else 50.0
+        )
+        prof_model = ProficiencyModel(
+            proficiency=avg_prof,
+            topic_proficiencies=topic_profs,
+        )
+
+        signals = derived.get("signals") or {}
+        emotional = EmotionalState(
+            confidence=personality["confidence"],
+            frustration=min(max(signals.get("frustration_rate", 0.1), 0.0), 1.0),
+            engagement=personality["curiosity"],
+        )
+
+        # Misconception strings from #62 surface here as "error patterns" so
+        # the existing on-mistake prompt branch can use them.
+        miscon = list(derived.get("misconceptions") or [])
+        if not miscon:
+            miscon = ["typical kid errors"]
+
+        name = display_name or profile.get("name") or "Student"
+        return StudentAgent(
+            student_id=f"der_{profile['student_id']}",
+            name=name,
+            nickname_ja=name,
+            grade=int(profile.get("grade") or 6),
+            subject=profile.get("subject", "math"),
+            personality=personality,
+            proficiency_model=prof_model,
+            emotional_state=emotional,
+            error_patterns=miscon[:3],
+        )
+
+    @staticmethod
     def create_custom(
         name: str,
         grade: int,

--- a/training_field/web/app.py
+++ b/training_field/web/app.py
@@ -25,6 +25,63 @@ from training_field.proficiency_model import CurriculumGraph
 from training_field.session_runner import PHASE_CONFIG, SessionConfig
 from training_field.student_profile_deriver import update_derived_profile
 
+# Derived StudentAgent surfacing (#63):
+# Reuse a real student's personality+signals to power agent-vs-agent
+# Observatory sessions. Eligibility threshold matches the issue spec.
+DERIVED_STUDENT_ID_PREFIX = "der_"
+MIN_SESSIONS_FOR_DERIVED = 3
+EXPOSE_REAL_STUDENT_NAMES = os.environ.get("EXPOSE_REAL_STUDENT_NAMES") == "1"
+
+
+def _build_student_agent(student_id: str):
+    """Resolve a `student_id` (canonical s001-s007 OR der_<stu_id>) to a
+    StudentAgent. Centralizes the dispatch so route handlers don't repeat it.
+    """
+    if student_id.startswith(DERIVED_STUDENT_ID_PREFIX):
+        real_id = student_id[len(DERIVED_STUDENT_ID_PREFIX):]
+        path = STUDENT_PROFILES_DIR / f"{real_id}.json"
+        # Anonymize unless the operator opted in via env var. The agent's
+        # display name is shown in transcripts and on the Observatory page.
+        display = None
+        if not EXPOSE_REAL_STUDENT_NAMES:
+            display = _anonymous_label_for(real_id)
+        return StudentAgentFactory.from_derived_profile(path, display_name=display)
+    return StudentAgentFactory.from_profile(student_id)
+
+
+def _anonymous_label_for(real_id: str) -> str:
+    """Stable, non-identifying label like 'Student #3' for a profile id.
+
+    Order is alphabetical over derived-eligible profile ids so the same
+    user gets the same number across page loads.
+    """
+    eligible = sorted(_eligible_derived_profile_ids())
+    try:
+        idx = eligible.index(real_id) + 1
+    except ValueError:
+        # Profile became ineligible between calls — fall back to a hash-ish
+        # but stable label.
+        idx = (sum(ord(c) for c in real_id) % 99) + 1
+    return f"Student #{idx}"
+
+
+def _eligible_derived_profile_ids() -> list[str]:
+    """Profile ids that have enough observed sessions to be a meaningful
+    Observatory persona. Empty list when the profiles dir is missing."""
+    if not STUDENT_PROFILES_DIR.exists():
+        return []
+    out: list[str] = []
+    for path in STUDENT_PROFILES_DIR.glob("*.json"):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        derived = data.get("derived") or {}
+        if (derived.get("sessions_observed") or 0) >= MIN_SESSIONS_FOR_DERIVED:
+            out.append(data.get("student_id") or path.stem)
+    return out
+
+
 app = FastAPI(title="Agent Training Field")
 app.add_middleware(
     CORSMiddleware,
@@ -1105,6 +1162,10 @@ async def observatory(request: Request):
         results = reg.query(filter_by={"student_id": sid})
         last_gain = results[0]["learning_gain"] if results else None
         student_data.append({**info, "id": sid, "sessions": len(results), "last_gain": last_gain})
+    # Derived students from real Live sessions (#63). Eligible = enough
+    # observed sessions to have a meaningful personality.
+    derived_data = _list_derived_students_for_observatory(reg)
+    student_data.extend(derived_data)
     return templates.TemplateResponse(request, "dashboard.html", {
         "students": student_data,
         "summary": summary, "recent": reg.query(limit=5),
@@ -1112,9 +1173,56 @@ async def observatory(request: Request):
         "STUDENT_NAMES": {sid: info["name"] for sid, info in STUDENTS.items()},
     })
 
+
+def _list_derived_students_for_observatory(reg) -> list[dict]:
+    """Build dashboard cards for each eligible derived student."""
+    out: list[dict] = []
+    eligible = sorted(_eligible_derived_profile_ids())
+    if not eligible:
+        return out
+    # Predictable colors so each derived agent has a distinguishable card.
+    palette = ["#64748b", "#0f766e", "#9333ea", "#0284c7", "#b45309", "#be185d"]
+    for i, real_id in enumerate(eligible):
+        path = STUDENT_PROFILES_DIR / f"{real_id}.json"
+        try:
+            profile = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        derived = profile.get("derived") or {}
+        agent_id = f"{DERIVED_STUDENT_ID_PREFIX}{real_id}"
+        display = (
+            profile.get("name", real_id) if EXPOSE_REAL_STUDENT_NAMES
+            else _anonymous_label_for(real_id)
+        )
+        # Average proficiency from accumulated topic scores (matches what
+        # _build_student_agent uses as baseline).
+        topic_profs = profile.get("proficiency") or {}
+        prof_baseline = (
+            int(round(sum(topic_profs.values()) / len(topic_profs)))
+            if topic_profs else 50
+        )
+        results = reg.query(filter_by={"student_id": agent_id})
+        last_gain = results[0]["learning_gain"] if results else None
+        personality_desc = (derived.get("personality") or {}).get("description") or "Auto-derived from Live sessions."
+        out.append({
+            "id": agent_id,
+            "name": display,
+            "nickname": display,
+            "prof_baseline": prof_baseline,
+            "personality": personality_desc,
+            "color": palette[i % len(palette)],
+            "sessions": len(results),
+            "last_gain": last_gain,
+            "is_derived": True,
+            "sessions_observed": derived.get("sessions_observed", 0),
+        })
+    return out
+
 @app.get("/session/{student_id}", response_class=HTMLResponse)
 async def session_page(request: Request, student_id: str, grade: str = "小6", subject: str = "算数"):
-    info = STUDENTS.get(student_id, {})
+    info = _resolve_student_info_for_observatory(student_id)
+    if not info:
+        raise HTTPException(404, f"unknown student_id: {student_id}")
     reg = ExperimentRegistry()
     history = reg.query(filter_by={"student_id": student_id}, limit=10)
     gcode = GRADE_CODES.get(grade, 6)
@@ -1126,6 +1234,41 @@ async def session_page(request: Request, student_id: str, grade: str = "小6", s
         "topic_tx_en": TOPIC_TX_EN,
         "teachers": list_teachers(),
     })
+
+
+def _resolve_student_info_for_observatory(student_id: str) -> dict:
+    """Look up the dashboard-style summary for either canonical or derived ids."""
+    if student_id in STUDENTS:
+        return STUDENTS[student_id]
+    if student_id.startswith(DERIVED_STUDENT_ID_PREFIX):
+        real_id = student_id[len(DERIVED_STUDENT_ID_PREFIX):]
+        path = STUDENT_PROFILES_DIR / f"{real_id}.json"
+        if not path.exists():
+            return {}
+        try:
+            profile = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+        derived = profile.get("derived") or {}
+        topic_profs = profile.get("proficiency") or {}
+        prof_baseline = (
+            int(round(sum(topic_profs.values()) / len(topic_profs)))
+            if topic_profs else 50
+        )
+        display = (
+            profile.get("name", real_id) if EXPOSE_REAL_STUDENT_NAMES
+            else _anonymous_label_for(real_id)
+        )
+        return {
+            "name": display,
+            "nickname": display,
+            "prof_baseline": prof_baseline,
+            "personality": (derived.get("personality") or {}).get(
+                "description", "Auto-derived from Live sessions."
+            ),
+            "color": "#64748b",
+        }
+    return {}
 
 @app.get("/api/teachers")
 async def api_teachers():
@@ -1271,7 +1414,7 @@ async def run_session(body: dict):
         run_post_test=body.get("run_post_test",False),
     )
     session_id = f"sess_{uuid.uuid4().hex[:8]}"
-    student = StudentAgentFactory.from_profile(config.student_id)
+    student = _build_student_agent(config.student_id)
     teacher = load_teacher(body.get("teacher_id"))
     principal = PrincipalAgent()
     evaluator = Evaluator()
@@ -1392,7 +1535,7 @@ async def run_session_stream(
             grade=gcode, subject=subject,
             run_pre_test=pre_test, run_post_test=post_test,
         )
-        student = StudentAgentFactory.from_profile(config.student_id)
+        student = _build_student_agent(config.student_id)
         teacher = load_teacher(teacher_id)
         principal = PrincipalAgent()
         evaluator = Evaluator()

--- a/training_field/web/templates/dashboard.html
+++ b/training_field/web/templates/dashboard.html
@@ -155,7 +155,7 @@ main{max-width:1280px;margin:0 auto;padding:96px 40px 140px}
   background:var(--surface);
   border:1px solid var(--border);
   border-radius:var(--radius-lg);
-  padding:28px;
+  padding:28px;position:relative;
   box-shadow:var(--shadow-sm);
   transition:transform .4s var(--ease),box-shadow .4s var(--ease),border-color .4s var(--ease);
 }
@@ -163,6 +163,13 @@ main{max-width:1280px;margin:0 auto;padding:96px 40px 140px}
   transform:translateY(-4px);
   box-shadow:var(--shadow-lg);
   border-color:var(--border-strong);
+}
+.student-card .derived-tag{
+  position:absolute;top:14px;right:14px;
+  font-size:10px;font-weight:600;letter-spacing:0.04em;
+  padding:3px 8px;border-radius:8px;
+  background:var(--surface-2);color:var(--text-secondary);
+  text-transform:uppercase;
 }
 .sc-head{display:flex;align-items:center;gap:14px;margin-bottom:24px}
 .avatar{
@@ -348,6 +355,9 @@ tbody tr:hover{background:var(--surface-2)}
     <div class="cards-grid">
       {% for s in students %}
       <a class="student-card stu-card" href="/session/{{ s.id }}" data-sid="{{ s.id }}">
+        {% if s.is_derived %}
+        <span class="derived-tag" data-i18n="derived_tag">From real session</span>
+        {% endif %}
         <div class="sc-head">
           <div class="avatar" style="background:{{ s.color }}1a;color:{{ s.color }}">{{ s.name[:2].upper() }}</div>
           <div>
@@ -355,6 +365,7 @@ tbody tr:hover{background:var(--surface-2)}
             <div class="sc-personality">{{ s.personality }}</div>
           </div>
         </div>
+        {% if not s.is_derived %}
         <div class="bars">
           {% for label, val in [("分数",42),("比",38),("速さ",35),("比例",40),("円",41),("場合",35)] %}
           <div class="bar-row">
@@ -364,6 +375,13 @@ tbody tr:hover{background:var(--surface-2)}
           </div>
           {% endfor %}
         </div>
+        {% else %}
+        <div style="font-size:12px;color:var(--text-secondary);line-height:1.6;margin-bottom:24px">
+          <span data-i18n="derived_observed">Calibrated from</span>
+          <strong>{{ s.sessions_observed }}</strong>
+          <span data-i18n="derived_observed_suffix">live session(s)</span>
+        </div>
+        {% endif %}
         <div class="sc-foot">
           <span class="sc-foot-meta">{{ s.sessions }} <span data-i18n="sessions_word">sessions</span></span>
           {% if s.last_gain and s.last_gain > 0 %}
@@ -438,6 +456,7 @@ const I18N = {
     th_session:"セッション", th_student:"生徒", th_topic:"単元", th_depth:"深さ",
     th_pre:"事前", th_post:"事後", th_gain:"ゲイン", th_grade:"評価", th_delta:"Δ習熟",
     sessions_word:"セッション", pts:"点", no_test_yet:"テスト未実施", view_all:"すべて見る →",
+    derived_tag:"実セッション由来", derived_observed:"実セッション", derived_observed_suffix:"回から学習中",
     title_main:"AIエージェントが教え方を",
     title_faded:"学び、試し、本質を持ち帰るための静かな場。",
     title_sub:"現在、6種類の生徒ペルソナ、6種類のスキル(教え方)、5つの評価軸を備え、エージェントが成長のためのインサイトを得られます。",
@@ -455,6 +474,7 @@ const I18N = {
     th_session:"Session", th_student:"Student", th_topic:"Topic", th_depth:"Depth",
     th_pre:"Pre", th_post:"Post", th_gain:"Gain", th_grade:"Grade", th_delta:"Δ Prof",
     sessions_word:"sessions", pts:"pts", no_test_yet:"no test yet", view_all:"View all →",
+    derived_tag:"From real session", derived_observed:"Calibrated from", derived_observed_suffix:"live session(s)",
     title_main:"A calm space for AI agents",
     title_faded:"to learn and experiment with how to teach and get key takeaways.",
     title_sub:"Currently, there are six types of student personas, six types of skills (ways to teach), and five pillars of evaluation feedback for agents to gain insights for growth.",


### PR DESCRIPTION
Closes #63. Builds on #62.

## Summary
- Once a real student has ≥3 Live sessions, their `derived` block (added in #62) now powers a selectable Observatory persona with id `der_<stu_id>`.
- `StudentAgentFactory.from_derived_profile()` builds a `StudentAgent` from `reports/students/{id}.json`: personality/signals from `derived`, proficiency from the accumulated map, up to 3 recorded misconceptions as `error_patterns`.
- Anonymized by default (`Student #N`); set `EXPOSE_REAL_STUDENT_NAMES=1` to show real names.
- Dashboard cards get a "From real session" tag and skip the canned bar chart (which would be misleading without per-topic signal yet).

## Test plan
- [ ] Confirm the dashboard at `/observatory` still renders with zero eligible derived students (clean install).
- [ ] After 3+ Live sessions for one real user, confirm a new card appears with the "From real session" tag.
- [ ] Click the derived card → `/session/der_<stu_id>` loads, panel-right shows the anonymized name + auto-derived personality string.
- [ ] Run an agent-vs-agent session against the derived student → `StudentAgent` uses the derived verbosity/patience/confidence in its prompts.
- [ ] Toggle `EXPOSE_REAL_STUDENT_NAMES=1` → real name shows. Toggle off → label reverts to `Student #N`.

## Privacy
- This is the first feature to expose one user's behavioral signal to another user (the experimenter). Names are anonymized by default; misconception phrases are still NOT rendered in the UI in this MVP. Privacy policy update tracked in #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)