### PR TITLE
Show derived StudentAgent in Observatory after the first Live session

### DIFF
--- a/training_field/web/app.py
+++ b/training_field/web/app.py
@@ -27,9 +27,12 @@ from training_field.student_profile_deriver import update_derived_profile
 
 # Derived StudentAgent surfacing (#63):
 # Reuse a real student's personality+signals to power agent-vs-agent
-# Observatory sessions. Eligibility threshold matches the issue spec.
+# Observatory sessions. We surface a derived persona starting from the
+# very first completed Live session — early signals are noisier, but
+# making the loop visible from day 1 is more useful than hiding it
+# behind a "wait for 3 sessions" gate.
 DERIVED_STUDENT_ID_PREFIX = "der_"
-MIN_SESSIONS_FOR_DERIVED = 3
+MIN_SESSIONS_FOR_DERIVED = 1
 EXPOSE_REAL_STUDENT_NAMES = os.environ.get("EXPOSE_REAL_STUDENT_NAMES") == "1"
 
 


### PR DESCRIPTION
## Summary
Drops the eligibility threshold for the derived StudentAgent surfacing (#63) from 3 to 1 — the agent appears in the Observatory immediately after a real student finishes their first Live session.

## Why
- Made it impossible to verify the calibration loop end-to-end without manually playing three full sessions.
- EWMA smoothing in `student_profile_deriver.py` already keeps a single noisy session from dominating the personality block.
- Card already shows `Calibrated from N live session(s)` so users can see how mature the calibration is.

## Test plan
- [ ] Wipe browser localStorage so /learn shows the onboarding form.
- [ ] Register as a new user and complete one full Live session (use the End button or run through post-test).
- [ ] Open `/observatory` → the new persona appears with the "From real session" tag and `Calibrated from 1 live session(s)` line.
- [ ] Hit `/api/student/<stu_id>` → response contains a `derived` block with personality + signals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)